### PR TITLE
ChatViewModel tests writing

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -30,7 +30,8 @@ class ChatViewModel(
   private val _errorMessage = MutableStateFlow<String?>(null)
   val errorMessage = _errorMessage.asStateFlow()
 
-  private val collectedAnalysisData = mutableListOf<AnalysisData>()
+  private val _collectedAnalysisData = MutableStateFlow<MutableList<AnalysisData>>(mutableListOf())
+  val collectedAnalysisData = _collectedAnalysisData.asStateFlow()
 
   private val practiceContext = apiLinkViewModel.practiceContext
 
@@ -40,7 +41,7 @@ class ChatViewModel(
 
   fun initializeConversation() {
 
-    collectedAnalysisData.clear() // Resets the analysis data history
+    _collectedAnalysisData.value.clear() // Resets the analysis data history
     val practiceContextAsValue = practiceContext.value ?: return
     val systemMessageContent =
         when (practiceContextAsValue) {
@@ -85,7 +86,7 @@ class ChatViewModel(
     val userMessage = Message(role = "user", content = transcript)
     _chatMessages.value += userMessage
 
-    collectedAnalysisData.add(analysisData)
+    _collectedAnalysisData.value.add(analysisData)
 
     getNextGPTResponse()
   }
@@ -147,7 +148,7 @@ class ChatViewModel(
   //    }
 
   private fun getAnalysisSummary(): String {
-    return generateAnalysisSummary(collectedAnalysisData)
+    return generateAnalysisSummary(_collectedAnalysisData.value)
   }
 
   private fun generateAnalysisSummary(analysisDataList: List<AnalysisData>): String {

--- a/app/src/test/java/com/github/se/orator/model/apiLink/ApiLinkViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/apiLink/ApiLinkViewModelTest.kt
@@ -1,0 +1,57 @@
+package com.github.se.orator.model.apiLink
+
+import com.github.se.orator.model.speaking.AnalysisData
+import com.github.se.orator.model.speaking.InterviewContext
+import org.junit.Before
+import org.junit.Test
+
+class ApiLinkViewModelTest {
+
+  private lateinit var apiLinkViewModel: ApiLinkViewModel
+
+  private val analysisData = AnalysisData("test", 0, 0.0, 0.0)
+  private val practiceContext = InterviewContext("test", "test", "test", listOf("test"))
+
+  @Before
+  fun setUp() {
+    apiLinkViewModel = ApiLinkViewModel()
+  }
+
+  @Test
+  fun testUpdateFields() {
+
+    // AnalysisData
+    apiLinkViewModel.updateAnalysisData(analysisData)
+    assert(apiLinkViewModel.analysisData.value == analysisData)
+
+    // PracticeContext
+    apiLinkViewModel.updatePracticeContext(practiceContext)
+    assert(apiLinkViewModel.practiceContext.value == practiceContext)
+  }
+
+  @Test
+  fun testClearFields() {
+
+    // AnalysisData
+    apiLinkViewModel.updateAnalysisData(analysisData)
+    apiLinkViewModel.clearAnalysisData()
+    assert(apiLinkViewModel.analysisData.value == null)
+
+    // PracticeContext
+    apiLinkViewModel.updatePracticeContext(practiceContext)
+    apiLinkViewModel.clearPracticeContext()
+    assert(apiLinkViewModel.practiceContext.value == null)
+  }
+
+  @Test
+  fun testClearAll() {
+
+    apiLinkViewModel.updateAnalysisData(analysisData)
+    apiLinkViewModel.updatePracticeContext(practiceContext)
+
+    apiLinkViewModel.resetAllPracticeData()
+
+    assert(apiLinkViewModel.analysisData.value == null)
+    assert(apiLinkViewModel.practiceContext.value == null)
+  }
+}

--- a/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
@@ -1,0 +1,162 @@
+package com.github.se.orator.model.chatGPT
+
+import com.github.se.orator.model.apiLink.ApiLinkViewModel
+import com.github.se.orator.model.speaking.AnalysisData
+import com.github.se.orator.model.speaking.InterviewContext
+import com.github.se.orator.model.speaking.PublicSpeakingContext
+import com.github.se.orator.model.speaking.SalesPitchContext
+import com.github.se.orator.ui.network.ChatGPTService
+import com.github.se.orator.ui.network.ChatResponse
+import com.github.se.orator.ui.network.Message
+import com.github.se.orator.ui.network.Usage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+
+class ChatViewModelTest {
+
+  @Mock private lateinit var chatGPTService: ChatGPTService
+  @Mock private lateinit var apiLinkViewModel: ApiLinkViewModel
+
+  private lateinit var chatViewModel: ChatViewModel
+
+  private val testDispatcher = StandardTestDispatcher() // Using a test dispatcher
+
+  private val chatResp = ChatResponse("id", "object", 0, "model", emptyList(), Usage(0, 0, 0))
+
+  private val interviewContext =
+      InterviewContext("interviewType", "role", "company", listOf("focusArea"))
+  private val interviewExpected =
+      """You are simulating a ${interviewContext.interviewType} for the position of ${interviewContext.role} at ${interviewContext.company}. 
+        |Focus on the following areas: ${interviewContext.focusAreas.joinToString(", ")}. 
+        |Ask questions one at a time and wait for the user's response before proceeding. 
+        |Do not provide feedback until the end."""
+          .trimMargin()
+
+  private val publicContext =
+      PublicSpeakingContext("occasion", "audienceDemographic", listOf("mainPoint"))
+  private val publicExpected =
+      """You are helping the user prepare a speech for a ${publicContext.occasion}. 
+    |The audience is ${publicContext.audienceDemographic}. 
+    |The main points of the speech are: ${publicContext.mainPoints.joinToString(", ")}.
+    |Please guide the user through practicing their speech, asking for their input on each point.
+    """
+          .trimMargin()
+
+  private val salesContext = SalesPitchContext("product", "targetAudience", listOf("feature"))
+  private val salesExpected =
+      """You are helping the user prepare a sales pitch for the product ${salesContext.product}. 
+    |The target audience is ${salesContext.targetAudience}. 
+    |The key features of the product are: ${salesContext.keyFeatures.joinToString(", ")}.
+    |Please guide the user through practicing their sales pitch, asking for their input on each feature.
+    """
+          .trimMargin()
+
+  private val analysisData = AnalysisData("transcription", 0, 0.0, 0.0)
+
+  private val analysisDataState = MutableStateFlow<AnalysisData?>(null)
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    Dispatchers.setMain(testDispatcher) // Set the test dispatcher
+
+    chatGPTService = mock(ChatGPTService::class.java)
+    apiLinkViewModel = mock(ApiLinkViewModel::class.java)
+
+    // Mock the practice context value
+    `when`(apiLinkViewModel.practiceContext).thenReturn(MutableStateFlow(interviewContext))
+    // Mock the analysis data value
+    `when`(apiLinkViewModel.analysisData).thenReturn(analysisDataState)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain() // Reset the main dispatcher
+    testDispatcher.cancel()
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun initialzeConversationWorksProperly() = runTest {
+    var expected = interviewExpected
+
+    for (i in 1..3) {
+      // Create a ChatViewModel instance with the mocked ChatGPTService and ApiLinkViewModel
+      chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel)
+
+      // Call the initializeConversation method
+      chatViewModel.initializeConversation()
+
+      advanceUntilIdle()
+
+      // Verify that the chat messages are empty
+      assert(chatViewModel.chatMessages.value.size == 2)
+      assert(chatViewModel.chatMessages.value[0] == Message(role = "system", content = expected))
+      assert(
+          chatViewModel.chatMessages.value[1] ==
+              Message(role = "user", content = "I'm ready to begin the interview."))
+
+      if (i == 1) {
+        `when`(apiLinkViewModel.practiceContext).thenReturn(MutableStateFlow(publicContext))
+        expected = publicExpected
+      } else if (i == 2) {
+        `when`(apiLinkViewModel.practiceContext).thenReturn(MutableStateFlow(salesContext))
+        expected = salesExpected
+      }
+    }
+  }
+
+  @Test
+  fun analysisDataIsCorrectlyObserved() = runTest {
+    // Create a ChatViewModel instance with the mocked ChatGPTService and ApiLinkViewModel
+    chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel)
+
+    // Call the initializeConversation method
+    chatViewModel.initializeConversation()
+
+    // The list of collected analysis data should be empty
+    assert(chatViewModel.collectedAnalysisData.value.isEmpty())
+
+    // Set the analysis data state to the analysis data, this should trigger the sendUserResponse
+    // method in ChatViewModel
+    analysisDataState.value = analysisData
+
+    // Advance the test dispatcher (wait for the coroutine to finish)
+    advanceUntilIdle()
+
+    // Verify that the analysis data was collected
+    verify(apiLinkViewModel).analysisData
+    assert(chatViewModel.collectedAnalysisData.value.isNotEmpty())
+    assert(chatViewModel.collectedAnalysisData.value[0] == analysisData)
+  }
+
+  @Test
+  fun generateFeedbackCallsAPI() = runTest {
+    // Create a ChatViewModel instance with the mocked ChatGPTService and ApiLinkViewModel
+    chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel)
+    // Call the initializeConversation method
+    chatViewModel.initializeConversation()
+
+    // Verify that chatGPTService.getChatCompletion was called and retrieve the argument
+    `when`(chatGPTService.getChatCompletion(any())).thenReturn(chatResp)
+
+    // Call the generateFeedback method
+    assert(chatViewModel.generateFeedback() == chatResp.choices.firstOrNull()?.message?.content)
+    verify(chatGPTService).getChatCompletion(any())
+  }
+}


### PR DESCRIPTION
### New test class `ChatViewModelTest`:

* Added `ChatViewModelTest` to test the functionality of `ChatViewModel`, including initialization, state observation, and API interactions.
* Coverage : 86% in the package `com.github.se.orator.model.chatGPT`

#### Also added :
* `collectedAnalysisData` in `ChatViewModel.kt`, to retrieve the collected analysis data from the outside (will be usefull for the treatment of the data later).

