### PR TITLE
fix : add signing support to automate the building of APK

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,13 +60,18 @@ jobs:
 
           # Decode local.properties and add additional keys directly
           echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
-          echo "GPT_API_KEY=$GPT_API_KEY" >> ./local.properties
-          echo "GPT_ORGANIZATION_ID=$GPT_ORGANIZATION_ID" >> ./local.properties
-          echo "SONAR_TOKEN=$SONAR_TOKEN" >> ./local.properties
-          echo "SYMBL_APP_ID=$SYMBL_APP_ID" >> ./local.properties
-          echo "SYMBL_APP_SECRET=$SYMBL_APP_SECRET" >> ./local.properties
-      
-      
+          echo "GPT_API_KEY=$GPT_API_KEY" | base64 --decode>> ./local.properties
+          echo "GPT_ORGANIZATION_ID=$GPT_ORGANIZATION_ID" | base64 --decode>> ./local.properties
+          echo "SONAR_TOKEN=$SONAR_TOKEN" | base64 --decode>> ./local.properties
+          echo "SYMBL_APP_ID=$SYMBL_APP_ID" | base64 --decode >> ./local.properties
+          echo "SYMBL_APP_SECRET=$SYMBL_APP_SECRET" | base64 --decode>> ./local.properties
+
+      # Decode the keystore and save it as a file for Gradle to access
+      - name: Decode keystore file
+        env:
+          SIGNING_KEY_STORE_BASE64: ${{ secrets.SIGNING_KEY_STORE_BASE64 }}
+        run: |
+          echo "$SIGNING_KEY_STORE_BASE64" | base64 --decode > keystore.jks
 
       - name: Build APK
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ replay_pid*
 **/build
 local.properties
 keystore.properties
+keystore.jks
 .gradle
 /app/google-services.json
 /app/release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,15 @@ plugins {
 }
 
 android {
+    signingConfigs {
+        create("build") {
+            storeFile =
+                file("${rootProject.projectDir}/keystore.jks")
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
+        }
+    }
     namespace = "com.github.se.orator"
     compileSdk = 34
 
@@ -47,6 +56,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("build")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"


### PR DESCRIPTION
### PR Description

This pull request adds a missing feature to automate the signing of the APK. The following changes were made:

- **Automated APK Signing**: Implemented a signing configuration that dynamically uses environment variables to support automated signing in CI/CD environments.
- **Build Configuration Update**: Modified the `build.gradle.kts` to accommodate the signing process, ensuring secure handling of keystore files and credentials.

These changes streamline the build process, making it more efficient and secure for continuous integration and deployment.