### PR TITLE
fix SpeakingRepositoryTest inconsistency with code

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/model/symblAi/SpeakingRepositoyTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/model/symblAi/SpeakingRepositoyTest.kt
@@ -25,13 +25,13 @@ class SpeakingRepositoryTest {
     context = ApplicationProvider.getApplicationContext()
 
     // Initialize SpeakingRepository with the context
-    speakingRepository = SpeakingRepository(context)
+    speakingRepository = SpeakingRepositoryRecord(context)
   }
 
   @Test
   fun initial_state_should_be_IDLE() {
     // Assert that the initial state is IDLE
-    assertEquals(AnalysisState.IDLE, speakingRepository.analysisState.value)
+    assertEquals(SpeakingRepository.AnalysisState.IDLE, speakingRepository.analysisState.value)
   }
 
   @Test
@@ -40,19 +40,19 @@ class SpeakingRepositoryTest {
     speakingRepository.startRecording()
 
     // Assert
-    assertEquals(AnalysisState.RECORDING, speakingRepository.analysisState.value)
+    assertEquals(SpeakingRepository.AnalysisState.RECORDING, speakingRepository.analysisState.value)
   }
 
   @Test
   fun resetRecorder_should_set_state_back_to_IDLE() {
     // Arrange
     speakingRepository.startRecording()
-    assertEquals(AnalysisState.RECORDING, speakingRepository.analysisState.value)
+    assertEquals(SpeakingRepository.AnalysisState.RECORDING, speakingRepository.analysisState.value)
 
     // Act
     speakingRepository.resetRecorder()
 
     // Assert
-    assertEquals(AnalysisState.IDLE, speakingRepository.analysisState.value)
+    assertEquals(SpeakingRepository.AnalysisState.IDLE, speakingRepository.analysisState.value)
   }
 }


### PR DESCRIPTION
**Description:**

- Updated the SpeakingRepositoryTest to use the correct SpeakingRepository.AnalysisState constants.
- Modified assertions in the test cases to ensure consistency with the updated SpeakingRepository class structure.
- This change ensures that the tests accurately reflect the current state transitions of SpeakingRepository, improving test reliability and maintainability.