### PR TITLE
feature: implement log out functionality on the profile screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/profile/ProfileScreenTest.kt
@@ -92,6 +92,9 @@ class ProfileScreenTest {
 
     // Perform click on sign-out button
     composeTestRule.onNodeWithContentDescription("Sign out").performClick()
+
+    // Verify navigation to sign in screen
+    Mockito.verify(navigationActions).navigateTo(Screen.AUTH)
   }
 
   @Test

--- a/app/src/main/java/com/github/se/orator/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/ProfileScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.orator.ui.profile
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -27,7 +28,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Logout
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.QueryStats
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -61,9 +62,13 @@ import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
 import com.github.se.orator.ui.theme.AppShapes
 import com.github.se.orator.ui.theme.AppTypography
+import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions, profileViewModel: UserProfileViewModel) {
+  // Get the context
+  val context = LocalContext.current
+
   // State to control whether the profile picture dialog is open
   var isDialogOpen by remember { mutableStateOf(false) }
 
@@ -98,7 +103,12 @@ fun ProfileScreen(navigationActions: NavigationActions, profileViewModel: UserPr
             navigationIcon = {
               IconButton(
                   onClick = {
-                    // TODO: Implement sign-out functionality
+                    // Sign out the user
+                    FirebaseAuth.getInstance().signOut()
+                    // Display a toast message
+                    Toast.makeText(context, "Logout successful!", Toast.LENGTH_SHORT).show()
+                    // Navigate to the sign in screen
+                    navigationActions.navigateTo(Screen.AUTH)
                   },
                   modifier = Modifier.testTag("sign_out_button")) {
                     Icon(


### PR DESCRIPTION
### Summary

This PR implements the sign-out functionality for the log out button on the profile screen.

### Details

- When the sign-out button is clicked:
  - The user is signed out.
  - A toast message is displayed to confirm a successful log-out.
  - The user is redirected to the sign-in screen.
  
### Testing

- Added a test to verify the sign out button works as intended.
