### PR TITLE
Clean the `SymblApiClient` class

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
@@ -21,6 +21,12 @@ import org.json.JSONObject
 
 private const val CLASS_LOG_ID = "SymblApiClient"
 
+/**
+ * The SymblApiClient class is responsible for making API calls to the Symbl.ai API.
+ *
+ * @param context The context of the application.
+ * @param client The OkHttpClient instance to use for making API calls.
+ */
 class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttpClient()) :
     VoiceAnalysisApi {
 
@@ -203,6 +209,13 @@ class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttp
     }
   }
 
+  /**
+   * Function to get the transcription of an audio file.
+   *
+   * @param audioFile The audio file to be transcribed.
+   * @param onSuccess The function to be called on success.
+   * @param onFailure The function to be called on failure.
+   */
   override fun getTranscription(
       audioFile: File,
       onSuccess: (AnalysisData) -> Unit,

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
@@ -203,45 +203,6 @@ class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttp
     }
   }
 
-  // In phase of being modified
-  private fun parseFillerResponse(fillerJson: JSONObject) {
-    try {
-      val insightsArray = fillerJson.getJSONArray("insights")
-      if (insightsArray.length() > 0) {
-        val fillersBuilder = StringBuilder()
-
-        for (i in 0 until insightsArray.length()) {
-          val insightObject = insightsArray.getJSONObject(i)
-          val fillerWord = insightObject.getString("text")
-          fillersBuilder.append("Filler word: $fillerWord\n")
-        }
-
-        // Store the fillers result
-        fillersResult = fillersBuilder.toString()
-
-        // These will be fixed later on
-
-        /*// Notify listener
-          listener?.onProcessingComplete(
-              transcribedText = transcribedText,
-              sentimentResult = sentimentResult,
-              fillersResult = fillersResult)
-        } else {
-          fillersResult = "No filler words detected."
-
-          listener?.onProcessingComplete(
-              transcribedText = transcribedText,
-              sentimentResult = sentimentResult,
-              fillersResult = fillersResult)*/
-      }
-    } catch (e: Exception) {
-      /*
-      listener?.onError("Error parsing filler words: ${e.message}")
-      Log.e("Filler Parsing Error", e.message ?: "Unknown error")
-       */
-    }
-  }
-
   override fun getTranscription(
       audioFile: File,
       onSuccess: (AnalysisData) -> Unit,


### PR DESCRIPTION
A short PR removing the unused `parseFillerResponse` function of the `SymblApiClient` class, as well as adding some missing documentation for public elements.