### PR TITLE
Screenlock in portrait mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,7 +57,9 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Project">
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Project"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
This pull request includes a change to the `AndroidManifest.xml` file to improve the user experience by locking the screen orientation to portrait mode and addressing some warnings caused by this change.

##### Changes in `AndroidManifest.xml`:

* Locked the screen orientation to portrait mode.
* Suppressed specific warnings.