### PR TITLE
Feature: text to speech on chat screens

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/MainActivityTest.kt
@@ -42,6 +42,6 @@ class MainActivityTest {
 
   @Test
   fun noAppThemeViewModelDoesNotCrash() {
-    composeTestRule.setContent { OratorApp(mock(ChatGPTService::class.java), false, null) }
+    composeTestRule.setContent { OratorApp(mock(ChatGPTService::class.java), false, null, null) }
   }
 }

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -137,8 +137,8 @@ class MainActivity : ComponentActivity() {
 fun OratorApp(
     chatGPTService: ChatGPTService,
     isOffline: Boolean,
-    themeViewModel: AppThemeViewModel,
-    textToSpeech: TextToSpeech
+    themeViewModel: AppThemeViewModel? = null,
+    textToSpeech: TextToSpeech? = null
 ) {
   // Create NavController for navigation within the app
   val navController = rememberNavController()

--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.se.orator.model.chatGPT
 
+import android.speech.tts.TextToSpeech
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -18,7 +19,8 @@ import kotlinx.coroutines.launch
 
 class ChatViewModel(
     private val chatGPTService: ChatGPTService,
-    private val apiLinkViewModel: ApiLinkViewModel
+    private val apiLinkViewModel: ApiLinkViewModel,
+    private val textToSpeech: TextToSpeech? = null
 ) : ViewModel() {
 
   private var isConversationInitialized = false
@@ -158,6 +160,8 @@ class ChatViewModel(
 
         response.choices.firstOrNull()?.message?.let { responseMessage ->
           _chatMessages.value = _chatMessages.value + responseMessage
+
+          textToSpeech?.speak(responseMessage.toString(), TextToSpeech.QUEUE_FLUSH, null, "5x7CCx")
         }
       } catch (e: Exception) {
         handleError(e)

--- a/app/src/main/java/com/github/se/orator/ui/overview/ChatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/ChatScreen.kt
@@ -73,6 +73,7 @@ fun ChatScreen(navigationActions: NavigationActions, chatViewModel: ChatViewMode
               IconButton(
                   onClick = {
                     navigationActions.goBack()
+                    chatViewModel.toggleTextToSpeech(false)
                     chatViewModel.resetPracticeContext()
                     chatViewModel.endConversation()
                   },

--- a/app/src/main/java/com/github/se/orator/ui/overview/ChatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/ChatScreen.kt
@@ -127,7 +127,10 @@ fun ChatScreen(navigationActions: NavigationActions, chatViewModel: ChatViewMode
 
                     // Button to navigate to the "Speaking" screen to record a response.
                     Button(
-                        onClick = { navigationActions.navigateTo(Screen.SPEAKING) },
+                        onClick = {
+                          chatViewModel.toggleTextToSpeech(false)
+                          navigationActions.navigateTo(Screen.SPEAKING)
+                        },
                         modifier =
                             Modifier.fillMaxWidth()
                                 .padding(top = AppDimensions.paddingSmall)
@@ -148,7 +151,10 @@ fun ChatScreen(navigationActions: NavigationActions, chatViewModel: ChatViewMode
 
                     // Button to navigate to the "Feedback" screen to request feedback.
                     Button(
-                        onClick = { navigationActions.navigateTo(Screen.FEEDBACK) },
+                        onClick = {
+                          chatViewModel.toggleTextToSpeech(false)
+                          navigationActions.navigateTo(Screen.FEEDBACK)
+                        },
                         modifier =
                             Modifier.fillMaxWidth()
                                 .padding(top = AppDimensions.paddingSmall)

--- a/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.orator.model.chatGPT
 
+import android.speech.tts.TextToSpeech
 import com.github.se.orator.model.apiLink.ApiLinkViewModel
 import com.github.se.orator.model.speaking.AnalysisData
 import com.github.se.orator.model.speaking.InterviewContext
@@ -244,5 +245,50 @@ class ChatViewModelTest {
     // Call the generateFeedback method
     assert(chatViewModel.generateFeedback() == chatResp.choices.firstOrNull()?.message?.content)
     verify(chatGPTService).getChatCompletion(any())
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun observeTextToSpeechStateStopsTextToSpeechWhenInactive() = runTest {
+    // Mock TextToSpeech instance
+    val mockTextToSpeech = mock(TextToSpeech::class.java)
+
+    // Create a ChatViewModel instance with the mocked ChatGPTService, ApiLinkViewModel, and
+    // TextToSpeech
+    chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel, mockTextToSpeech)
+
+    // Initially, ensure TextToSpeech is active
+    assert(chatViewModel.isTextToSpeechActive.value)
+
+    // Set TextToSpeech state to inactive
+    chatViewModel.toggleTextToSpeech(false)
+
+    // Advance the test dispatcher to process the state change
+    advanceUntilIdle()
+
+    // Verify that TextToSpeech stop() method was called
+    verify(mockTextToSpeech).stop()
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun toggleTextToSpeechStateUpdatesCorrectly() = runTest {
+    // Create a ChatViewModel instance with the mocked ChatGPTService and ApiLinkViewModel
+    chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel)
+
+    // Initially, ensure TextToSpeech is active
+    assert(chatViewModel.isTextToSpeechActive.value)
+
+    // Toggle TextToSpeech state to inactive
+    chatViewModel.toggleTextToSpeech(false)
+
+    // Assert that the state is updated to inactive
+    assert(!chatViewModel.isTextToSpeechActive.value)
+
+    // Toggle TextToSpeech state back to active
+    chatViewModel.toggleTextToSpeech(true)
+
+    // Assert that the state is updated to active
+    assert(chatViewModel.isTextToSpeechActive.value)
   }
 }


### PR DESCRIPTION
A simple PR to implement a feature which consists of an AI voice reading out the interviewer's responses when on the chat screen.

**Files changed**:
MainActivity.kt : Initialization of the text to speech class instance and setting the speed of the speech so as to not be too slow and boring.

ChatViewModel.kt : to transform the GPT response text to audio as soon as it is received in the chat screen, also to cut off the audio when exiting the screen

ChatViewModelTest.kt : added unit tests to make sure the feature of cutting off the audio of the AI works