### PR TITLE
fix: offline recording crash

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -45,5 +45,7 @@ class RecordingReviewScreen {
     composeTestRule.onNodeWithTag("Back").assertIsDisplayed()
     composeTestRule.onNodeWithTag("hear_recording_button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("stop_recording_button").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("try_again").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("test_try_again").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -3,6 +3,7 @@ package com.github.se.orator.ui.offline
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import com.github.se.orator.model.apiLink.ApiLinkViewModel
 import com.github.se.orator.model.profile.UserProfileRepository
 import com.github.se.orator.model.profile.UserProfileViewModel
@@ -46,6 +47,6 @@ class RecordingReviewScreen {
     composeTestRule.onNodeWithTag("hear_recording_button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("stop_recording_button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("try_again").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("test_try_again").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Do another interview").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -55,6 +55,7 @@ class RecordingReviewScreen {
     composeTestRule.onNodeWithText("Stop recording").assertIsDisplayed()
   }
 
+  @Test
   fun testButtons() {
     composeTestRule.onNodeWithTag("try_again").performClick()
     verify(navigationActions).navigateTo(Screen.OFFLINE_INTERVIEW_MODULE)

--- a/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -4,16 +4,19 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.github.se.orator.model.apiLink.ApiLinkViewModel
 import com.github.se.orator.model.profile.UserProfileRepository
 import com.github.se.orator.model.profile.UserProfileViewModel
 import com.github.se.orator.model.symblAi.SpeakingRepository
 import com.github.se.orator.model.symblAi.SpeakingViewModel
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 
 class RecordingReviewScreen {
   @get:Rule val composeTestRule = createComposeRule()
@@ -48,5 +51,12 @@ class RecordingReviewScreen {
     composeTestRule.onNodeWithTag("stop_recording_button").assertIsDisplayed()
     composeTestRule.onNodeWithTag("try_again").assertIsDisplayed()
     composeTestRule.onNodeWithText("Do another interview").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Hear recording").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Stop recording").assertIsDisplayed()
+  }
+
+  fun testButtons() {
+    composeTestRule.onNodeWithTag("try_again").performClick()
+    verify(navigationActions).navigateTo(Screen.OFFLINE_INTERVIEW_MODULE)
   }
 }

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -153,8 +153,7 @@ fun OratorApp(
   val userProfileViewModel: UserProfileViewModel = viewModel(factory = UserProfileViewModel.Factory)
   val apiLinkViewModel = ApiLinkViewModel()
   val speakingViewModel =
-      SpeakingViewModel(
-          SpeakingRepositoryRecord(context), apiLinkViewModel, userProfileViewModel)
+      SpeakingViewModel(SpeakingRepositoryRecord(context), apiLinkViewModel, userProfileViewModel)
   val chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel, textToSpeech)
 
   // Scaffold composable to provide basic layout structure for the app
@@ -184,8 +183,7 @@ fun OratorApp(
               arguments = listOf(navArgument("question") { type = NavType.StringType })) {
                   backStackEntry ->
                 val question = backStackEntry.arguments?.getString("question") ?: ""
-                OfflineRecordingScreen(
-                    context, navigationActions, question, speakingViewModel)
+                OfflineRecordingScreen(context, navigationActions, question, speakingViewModel)
               }
 
           // Online/auth flow

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -147,13 +147,14 @@ fun OratorApp(
   val navController = rememberNavController()
   // Initialize NavigationActions to handle navigation events
   val navigationActions = NavigationActions(navController)
+  val context = LocalContext.current
 
   // Initialize required ViewModels using ViewModel.compose APIs
   val userProfileViewModel: UserProfileViewModel = viewModel(factory = UserProfileViewModel.Factory)
   val apiLinkViewModel = ApiLinkViewModel()
   val speakingViewModel =
       SpeakingViewModel(
-          SpeakingRepositoryRecord(LocalContext.current), apiLinkViewModel, userProfileViewModel)
+          SpeakingRepositoryRecord(context), apiLinkViewModel, userProfileViewModel)
   val chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel, textToSpeech)
 
   // Scaffold composable to provide basic layout structure for the app
@@ -184,7 +185,7 @@ fun OratorApp(
                   backStackEntry ->
                 val question = backStackEntry.arguments?.getString("question") ?: ""
                 OfflineRecordingScreen(
-                    LocalContext.current, navigationActions, question, speakingViewModel)
+                    context, navigationActions, question, speakingViewModel)
               }
 
           // Online/auth flow
@@ -233,7 +234,7 @@ fun OratorApp(
 
             composable(Screen.FEEDBACK_SCREEN) {
               PreviousRecordingsFeedbackScreen(
-                  LocalContext.current, navigationActions, chatViewModel, speakingViewModel)
+                  context, navigationActions, chatViewModel, speakingViewModel)
             }
 
             composable(Screen.EDIT_PROFILE) {

--- a/app/src/main/java/com/github/se/orator/model/symblAi/AudioRecorder.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/AudioRecorder.kt
@@ -70,13 +70,12 @@ class AudioRecorder(
 
           outputStream.close()
           recordingListener?.onRecordingFinished(audioFile)
-      if (audioFile.exists()) {
-        Log.d("AudioRecorder", "File exists and is ready for playback.")
-      } else {
-        Log.e("AudioRecorder", "File does not exist after saving.")
-      }
-
-    }
+          if (audioFile.exists()) {
+            Log.d("AudioRecorder", "File exists and is ready for playback.")
+          } else {
+            Log.e("AudioRecorder", "File does not exist after saving.")
+          }
+        }
         .start()
   }
 
@@ -98,7 +97,6 @@ class AudioRecorder(
       } catch (e: Exception) {
         Log.e("AudioRecorder", "Error releasing AudioRecord: ${e.message}", e)
       }
-
     }
   }
 

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepository.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepository.kt
@@ -8,7 +8,8 @@ interface SpeakingRepository {
   val analysisState: StateFlow<AnalysisState>
 
   fun startRecording(audioFile: File)
-    fun startRecording()
+
+  fun startRecording()
 
   fun getTranscript(
       audioFile: File,

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepository.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepository.kt
@@ -7,7 +7,8 @@ import kotlinx.coroutines.flow.StateFlow
 interface SpeakingRepository {
   val analysisState: StateFlow<AnalysisState>
 
-  fun startRecording()
+  fun startRecording(audioFile: File)
+    fun startRecording()
 
   fun getTranscript(
       audioFile: File,

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
@@ -25,10 +25,11 @@ class SpeakingRepositoryRecord(private val context: Context) : SpeakingRepositor
     _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
     audioRecorder.startRecording(audioFile)
   }
-    override fun startRecording() { // this is where the bug is from
-        _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
-        audioRecorder.startRecording(File(context.cacheDir, "audio_record.wav"))
-    }
+
+  override fun startRecording() { // this is where the bug is from
+    _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
+    audioRecorder.startRecording(File(context.cacheDir, "audio_record.wav"))
+  }
 
   override fun startRecordingToFile(audioFile: File) {
     audioRecorder.startRecording(audioFile)

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
@@ -22,17 +22,20 @@ class SpeakingRepositoryRecord(private val context: Context) : SpeakingRepositor
 
   // Functions to start and stop recording
 
-  // Function to start recording to a specific file
-  override fun startRecording(audioFile: File) {
-    _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
-    audioRecorder.startRecording(audioFile)
-  }
-
-  // Function to start recording to the default file kept for backwards compatibility
+  // Function to start recording to the default file "audio_record.wav" kept for backwards
+  // compatibility
   // with the speaking screens
   override fun startRecording() {
     _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
     audioRecorder.startRecording(File(context.cacheDir, "audio_record.wav"))
+  }
+
+  // This overload of startRecording() allows specifying a custom audio file name.
+  // It was introduced to ensure that the recorded audio can be saved under a unique,
+  // caller-defined filename, preventing conflicts and issues in playback due to default names.
+  override fun startRecording(audioFile: File) {
+    _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
+    audioRecorder.startRecording(audioFile)
   }
 
   override fun startRecordingToFile(audioFile: File) {

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
@@ -21,10 +21,14 @@ class SpeakingRepositoryRecord(private val context: Context) : SpeakingRepositor
   override val analysisState: StateFlow<SpeakingRepository.AnalysisState> = _analysisState
 
   // Functions to start and stop recording
-  override fun startRecording() {
+  override fun startRecording(audioFile: File) {
     _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
-    audioRecorder.startRecording()
+    audioRecorder.startRecording(audioFile)
   }
+    override fun startRecording() { // this is where the bug is from
+        _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
+        audioRecorder.startRecording(File(context.cacheDir, "audio_record.wav"))
+    }
 
   override fun startRecordingToFile(audioFile: File) {
     audioRecorder.startRecording(audioFile)

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingRepositoryRecord.kt
@@ -21,12 +21,16 @@ class SpeakingRepositoryRecord(private val context: Context) : SpeakingRepositor
   override val analysisState: StateFlow<SpeakingRepository.AnalysisState> = _analysisState
 
   // Functions to start and stop recording
+
+  // Function to start recording to a specific file
   override fun startRecording(audioFile: File) {
     _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
     audioRecorder.startRecording(audioFile)
   }
 
-  override fun startRecording() { // this is where the bug is from
+  // Function to start recording to the default file kept for backwards compatibility
+  // with the speaking screens
+  override fun startRecording() {
     _analysisState.value = SpeakingRepository.AnalysisState.RECORDING
     audioRecorder.startRecording(File(context.cacheDir, "audio_record.wav"))
   }

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingViewModel.kt
@@ -60,7 +60,7 @@ class SpeakingViewModel(
   }
 
   // Function to handle microphone button click
-  fun onMicButtonClicked(permissionGranted: Boolean) {
+  fun onMicButtonClicked(permissionGranted: Boolean, audioFile: File) {
     if (permissionGranted) {
       if (isRecording.value) {
         repository.stopRecording()
@@ -73,7 +73,7 @@ class SpeakingViewModel(
               userProfileViewModel.updateMetricMean()
             },
             onFailure = { error -> _analysisError.value = error })
-        repository.startRecording()
+        repository.startRecording(audioFile)
         _isRecording.value = true
       }
     } else {

--- a/app/src/main/java/com/github/se/orator/ui/offline/OfflineRecordingScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/offline/OfflineRecordingScreen.kt
@@ -43,6 +43,7 @@ fun OfflineRecordingScreen(
       mutableStateOf(false)
     } // Makes for easier testing
 ) {
+    val fileSaved = MutableStateFlow(false)
   val analysisState = remember {
     MutableStateFlow(SpeakingRepository.AnalysisState.IDLE)
   } // viewModel.analysisState.collectAsState()
@@ -54,7 +55,6 @@ fun OfflineRecordingScreen(
   //        AndroidAudioPlayer(context)
   //    }
 
-  var audioFile: File? = null // Keep this!! It should not be greyed out (bug?)
   val permissionLauncher =
       rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) {
           isGranted ->
@@ -118,11 +118,8 @@ fun OfflineRecordingScreen(
                         funRec = {
                           // what to do when user begins to record a file
                           if (analysisState.value == SpeakingRepository.AnalysisState.IDLE) {
-                            File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3")
-                                .also {
-                                  recorder.startRecording(it)
-                                  audioFile = it
-                                }
+                              recorder.startRecording(File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3"))
+
                             Log.d(
                                 "aa",
                                 "now transcribing to: ${viewModel.interviewPromptNb.value}.mp3")
@@ -137,12 +134,15 @@ fun OfflineRecordingScreen(
                                       "aall",
                                       " file saved to: \"${viewModel.interviewPromptNb.value}.mp3\"")
                                   recorder.stopRecording()
+                                    fileSaved.value = true
                                 }
                             analysisState.value = SpeakingRepository.AnalysisState.FINISHED
                           } else {
                             Log.d("offline recording screen issue", "Unrecognized analysis state!")
                           }
-                        })
+                        },
+                        audioFile = File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3")
+                        )
                   }
 
               Spacer(modifier = Modifier.height(AppDimensions.paddingMedium))
@@ -178,8 +178,11 @@ fun OfflineRecordingScreen(
               // button for user to click when he is done recording
               Button(
                   onClick = {
-                    viewModel.endAndSave()
-                    navigationActions.navigateTo(Screen.OFFLINE_RECORDING_REVIEW_SCREEN)
+                      if (fileSaved.value) {
+                          viewModel.endAndSave()
+                          fileSaved.value = false
+                          navigationActions.navigateTo(Screen.OFFLINE_RECORDING_REVIEW_SCREEN)
+                      }
                   },
                   modifier =
                       Modifier.fillMaxWidth(0.6f)

--- a/app/src/main/java/com/github/se/orator/ui/offline/OfflineRecordingScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/offline/OfflineRecordingScreen.kt
@@ -43,7 +43,7 @@ fun OfflineRecordingScreen(
       mutableStateOf(false)
     } // Makes for easier testing
 ) {
-    val fileSaved = MutableStateFlow(false)
+  val fileSaved = MutableStateFlow(false)
   val analysisState = remember {
     MutableStateFlow(SpeakingRepository.AnalysisState.IDLE)
   } // viewModel.analysisState.collectAsState()
@@ -118,7 +118,8 @@ fun OfflineRecordingScreen(
                         funRec = {
                           // what to do when user begins to record a file
                           if (analysisState.value == SpeakingRepository.AnalysisState.IDLE) {
-                              recorder.startRecording(File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3"))
+                            recorder.startRecording(
+                                File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3"))
 
                             Log.d(
                                 "aa",
@@ -134,15 +135,15 @@ fun OfflineRecordingScreen(
                                       "aall",
                                       " file saved to: \"${viewModel.interviewPromptNb.value}.mp3\"")
                                   recorder.stopRecording()
-                                    fileSaved.value = true
+                                  fileSaved.value = true
                                 }
                             analysisState.value = SpeakingRepository.AnalysisState.FINISHED
                           } else {
                             Log.d("offline recording screen issue", "Unrecognized analysis state!")
                           }
                         },
-                        audioFile = File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3")
-                        )
+                        audioFile =
+                            File(context.cacheDir, "${viewModel.interviewPromptNb.value}.mp3"))
                   }
 
               Spacer(modifier = Modifier.height(AppDimensions.paddingMedium))
@@ -178,11 +179,11 @@ fun OfflineRecordingScreen(
               // button for user to click when he is done recording
               Button(
                   onClick = {
-                      if (fileSaved.value) {
-                          viewModel.endAndSave()
-                          fileSaved.value = false
-                          navigationActions.navigateTo(Screen.OFFLINE_RECORDING_REVIEW_SCREEN)
-                      }
+                    if (fileSaved.value) {
+                      viewModel.endAndSave()
+                      fileSaved.value = false
+                      navigationActions.navigateTo(Screen.OFFLINE_RECORDING_REVIEW_SCREEN)
+                    }
                   },
                   modifier =
                       Modifier.fillMaxWidth(0.6f)

--- a/app/src/main/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -67,7 +67,10 @@ fun RecordingReviewScreen(
             colors =
                 ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
             onClick = { navigationActions.navigateTo(Screen.OFFLINE_INTERVIEW_MODULE) }) {
-              Text(text = "Do another interview", color = MaterialTheme.colorScheme.surface)
+              Text(
+                  text = "Do another interview",
+                  color = MaterialTheme.colorScheme.surface,
+                  modifier = Modifier.testTag("text_try_again"))
             }
 
         Row(

--- a/app/src/main/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -38,7 +38,7 @@ fun RecordingReviewScreen(
 
   val audioFile: File = File(context.cacheDir, "${speakingViewModel.interviewPromptNb.value}.mp3")
 
-    Log.d("rec screen review", "the file that you shall play is $audioFile")
+  Log.d("rec screen review", "the file that you shall play is $audioFile")
   Column(
       modifier =
           Modifier.fillMaxSize()
@@ -48,24 +48,27 @@ fun RecordingReviewScreen(
       horizontalAlignment = Alignment.CenterHorizontally) {
         Button(
             modifier = Modifier.testTag("hear_recording_button"),
-            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            colors =
+                ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
             onClick = { player.playFile(audioFile) }) {
               Text(text = "Hear recording", color = MaterialTheme.colorScheme.surface)
             }
 
         Button(
             modifier = Modifier.testTag("stop_recording_button"),
-            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            colors =
+                ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
             onClick = { player.stop() }) {
-          Text(text = "Stop recording", color = MaterialTheme.colorScheme.surface)
-        }
+              Text(text = "Stop recording", color = MaterialTheme.colorScheme.surface)
+            }
 
-      Button(
-          modifier = Modifier.testTag("try_again"),
-          colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-          onClick = { navigationActions.navigateTo(Screen.OFFLINE_INTERVIEW_MODULE)}) {
-          Text(text = "Do another interview", color = MaterialTheme.colorScheme.surface)
-      }
+        Button(
+            modifier = Modifier.testTag("try_again"),
+            colors =
+                ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            onClick = { navigationActions.navigateTo(Screen.OFFLINE_INTERVIEW_MODULE) }) {
+              Text(text = "Do another interview", color = MaterialTheme.colorScheme.surface)
+            }
 
         Row(
             modifier = Modifier.fillMaxWidth().testTag("Back"),

--- a/app/src/main/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/offline/RecordingReviewScreen.kt
@@ -1,11 +1,13 @@
 package com.github.se.orator.ui.offline
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -19,6 +21,7 @@ import com.github.se.orator.model.symblAi.AndroidAudioPlayer
 import com.github.se.orator.model.symblAi.AudioRecorder
 import com.github.se.orator.model.symblAi.SpeakingViewModel
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.Screen
 import com.github.se.orator.ui.theme.AppDimensions
 import java.io.File
 
@@ -35,6 +38,7 @@ fun RecordingReviewScreen(
 
   val audioFile: File = File(context.cacheDir, "${speakingViewModel.interviewPromptNb.value}.mp3")
 
+    Log.d("rec screen review", "the file that you shall play is $audioFile")
   Column(
       modifier =
           Modifier.fillMaxSize()
@@ -44,13 +48,24 @@ fun RecordingReviewScreen(
       horizontalAlignment = Alignment.CenterHorizontally) {
         Button(
             modifier = Modifier.testTag("hear_recording_button"),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
             onClick = { player.playFile(audioFile) }) {
-              Text(text = "Hear recording")
+              Text(text = "Hear recording", color = MaterialTheme.colorScheme.surface)
             }
 
-        Button(modifier = Modifier.testTag("stop_recording_button"), onClick = { player.stop() }) {
-          Text(text = "Stop recording")
+        Button(
+            modifier = Modifier.testTag("stop_recording_button"),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            onClick = { player.stop() }) {
+          Text(text = "Stop recording", color = MaterialTheme.colorScheme.surface)
         }
+
+      Button(
+          modifier = Modifier.testTag("try_again"),
+          colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+          onClick = { navigationActions.navigateTo(Screen.OFFLINE_INTERVIEW_MODULE)}) {
+          Text(text = "Do another interview", color = MaterialTheme.colorScheme.surface)
+      }
 
         Row(
             modifier = Modifier.fillMaxWidth().testTag("Back"),

--- a/app/src/main/java/com/github/se/orator/ui/speaking/SpeakingFunctions.kt
+++ b/app/src/main/java/com/github/se/orator/ui/speaking/SpeakingFunctions.kt
@@ -43,6 +43,7 @@ import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
 import com.github.se.orator.ui.theme.AppShapes
 import kotlinx.coroutines.delay
+import java.io.File
 
 /**
  * A composable that visualizes audio amplitudes as a waveform.
@@ -85,7 +86,8 @@ fun MicrophoneButton(
     analysisState: State<SpeakingRepository.AnalysisState>,
     permissionGranted: MutableState<Boolean>,
     context: Context,
-    funRec: () -> Unit = {}
+    funRec: () -> Unit = {},
+    audioFile: File = File(context.cacheDir, "audio_record.wav")
 ) {
   val infiniteTransition = rememberInfiniteTransition(label = "")
   val requestPerms = remember { mutableStateOf(false) }
@@ -105,7 +107,7 @@ fun MicrophoneButton(
           Toast.makeText(context, "You need to allow permissions!", Toast.LENGTH_SHORT).show()
         }
         funRec()
-        viewModel.onMicButtonClicked(permissionGranted.value)
+        viewModel.onMicButtonClicked(permissionGranted.value, audioFile)
       },
       modifier =
           Modifier.size(AppDimensions.buttonSize)

--- a/app/src/main/java/com/github/se/orator/ui/speaking/SpeakingFunctions.kt
+++ b/app/src/main/java/com/github/se/orator/ui/speaking/SpeakingFunctions.kt
@@ -42,8 +42,8 @@ import com.github.se.orator.model.symblAi.SpeakingViewModel
 import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
 import com.github.se.orator.ui.theme.AppShapes
-import kotlinx.coroutines.delay
 import java.io.File
+import kotlinx.coroutines.delay
 
 /**
  * A composable that visualizes audio amplitudes as a waveform.

--- a/app/src/test/java/com/github/se/orator/model/symblAi/AudioRecorderTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/symblAi/AudioRecorderTest.kt
@@ -125,4 +125,41 @@ class AudioRecorderTest {
     verify(mockAudioRecord).stop()
     verify(mockAudioRecord).release()
   }
+
+  @Test
+  fun testSaveRecordingToCorrectFile() {
+    val audioData = ByteArray(1024) { 0x55 } // Sample audio data
+    val tempFile = File.createTempFile("test_audio_correct", ".wav")
+    tempFile.deleteOnExit()
+
+    // Save the audio data to the file
+    audioRecorder.saveAsWavFile(audioData, tempFile)
+
+    // Verify the file exists
+    assertTrue(tempFile.exists())
+
+    // Verify the file is not empty
+    assertTrue(tempFile.length() > 0)
+
+    // Verify the file path is correct
+    assertEquals(tempFile.absolutePath, tempFile.path)
+
+    // check the file size is correct
+    val fileBytes = tempFile.readBytes()
+    assertTrue(fileBytes.size == 44 + audioData.size) // Header + audio data
+
+    // Verify headers
+    assertEquals('R'.code.toByte(), fileBytes[0])
+    assertEquals('I'.code.toByte(), fileBytes[1])
+    assertEquals('F'.code.toByte(), fileBytes[2])
+    assertEquals('F'.code.toByte(), fileBytes[3])
+
+    // Verify WAVE header
+    assertEquals('W'.code.toByte(), fileBytes[8])
+    assertEquals('A'.code.toByte(), fileBytes[9])
+    assertEquals('V'.code.toByte(), fileBytes[10])
+    assertEquals('E'.code.toByte(), fileBytes[11])
+    val recordedAudioData = fileBytes.sliceArray(44 until fileBytes.size)
+    assertArrayEquals(audioData, recordedAudioData)
+  }
 }

--- a/app/src/test/java/com/github/se/orator/model/symblAi/AudioRecorderTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/symblAi/AudioRecorderTest.kt
@@ -100,7 +100,7 @@ class AudioRecorderTest {
           }
           .thenReturn(PackageManager.PERMISSION_DENIED)
 
-      audioRecorder.startRecording()
+      audioRecorder.startRecording(File(context.cacheDir, "audio_record.wav"))
     }
   }
 

--- a/app/src/test/java/com/github/se/orator/model/symblAi/SpeakingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/symblAi/SpeakingViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.github.se.orator.model.symblAi
 
+import android.content.Context
 import com.github.se.orator.model.apiLink.ApiLinkViewModel
 import com.github.se.orator.model.profile.UserProfileViewModel
 import com.github.se.orator.model.speaking.AnalysisData
@@ -15,6 +16,7 @@ class SpeakingViewModelTest {
   private lateinit var apiLinkViewModel: ApiLinkViewModel
   private lateinit var speakingViewModel: SpeakingViewModel
   private lateinit var userProfileViewModel: UserProfileViewModel
+  private lateinit var context: Context
   private val testDispatcher = UnconfinedTestDispatcher()
 
   @Before
@@ -22,6 +24,8 @@ class SpeakingViewModelTest {
     speakingRepository = mock()
     apiLinkViewModel = mock()
     userProfileViewModel = mock()
+    context = mock()
+
     speakingViewModel =
         SpeakingViewModel(speakingRepository, apiLinkViewModel, userProfileViewModel)
   }
@@ -30,10 +34,10 @@ class SpeakingViewModelTest {
   fun `onMicButtonClicked starts recording and sets isRecording to true when permission is granted`() =
       runTest {
         // Act
-        speakingViewModel.onMicButtonClicked(true)
+        speakingViewModel.onMicButtonClicked(true, File(context.cacheDir, "audio_record.wav"))
         // Assert
         verify(speakingRepository).setupAnalysisResultsUsage(any(), any())
-        verify(speakingRepository).startRecording()
+        verify(speakingRepository).startRecording(any())
         Assert.assertTrue(speakingViewModel.isRecording.value)
       }
 
@@ -43,10 +47,12 @@ class SpeakingViewModelTest {
         // Arrange
         speakingViewModel =
             SpeakingViewModel(speakingRepository, apiLinkViewModel, userProfileViewModel)
-        speakingViewModel.onMicButtonClicked(true) // Start recording
+        speakingViewModel.onMicButtonClicked(
+            true, File(context.cacheDir, "audio_record.wav")) // Start recording
         reset(speakingRepository) // Reset to verify stopRecording
         // Act
-        speakingViewModel.onMicButtonClicked(true) // Stop recording
+        speakingViewModel.onMicButtonClicked(
+            true, File(context.cacheDir, "audio_record.wav")) // Stop recording
         // Assert
         verify(speakingRepository).stopRecording()
         Assert.assertFalse(speakingViewModel.isRecording.value)
@@ -61,7 +67,7 @@ class SpeakingViewModelTest {
       onSuccess(analysisData) // Simulate success callback
     }
     // Act
-    speakingViewModel.onMicButtonClicked(true)
+    speakingViewModel.onMicButtonClicked(true, File(context.cacheDir, "audio_record.wav"))
     // Assert
     assert(speakingViewModel.analysisData.value == analysisData)
   }
@@ -72,10 +78,10 @@ class SpeakingViewModelTest {
     // Initial state: not recording
     Assert.assertFalse(speakingViewModel.isRecording.value)
     // Act: Start recording
-    speakingViewModel.onMicButtonClicked(true)
+    speakingViewModel.onMicButtonClicked(true, File(context.cacheDir, "audio_record.wav"))
     Assert.assertTrue(speakingViewModel.isRecording.value)
     // Act: Stop recording
-    speakingViewModel.onMicButtonClicked(true)
+    speakingViewModel.onMicButtonClicked(true, File(context.cacheDir, "audio_record.wav"))
     Assert.assertFalse(speakingViewModel.isRecording.value)
   }
 


### PR DESCRIPTION
Due to issues with merge conflicts some of the logic to save the files was modified and causes crashes.
The exact issue is: When recording sometimes the file is sometimes wrongly saved under the name "audio_record.wav" and so when trying to play it in the review offline recording screen or offline recording feedback screen the app would crash.

The issue is due to: SpeakingViewModel using the function startRecording() which would by default save the values to "audio_record.wav"
How it was fixed: A new function startRecording(audioFile: File) has been added to AudioRecorder and AudioRecorderRepository is now called to save the file with the correct file name.


### **Fix for File Naming Issue in Offline Recording**

**Problem:**
The app crashes during playback in the review or feedback screen because the recorded file is sometimes saved with the default name `audio_record.wav`, causing a mismatch when the correct file name is expected (which is a random string generated per interview to allow the device to correctly store a lot of interviews).

**Root Cause:**
The `SpeakingViewModel` uses the `startRecording()` function, which defaults to saving files as `audio_record.wav`. This leads to conflicts and crashes during playback since the expected file name differs.

**Solution:**
1. Introduced a new function `startRecording(audioFile: File)` in `AudioRecorder` to manually select the file name.
2. Updated `AudioRecorderRepository` and `SpeakingViewModel` to use this function, ensuring the correct file name is used consistently.

**Key Changes:**
- Refactored `AudioRecorder` and `SpeakingRepositoryRecord` to accept a `File` parameter for saving.
- Updated UI components (`OfflineRecordingScreen`, `RecordingReviewScreen`) to pass the correct file name.
- Now creating one context val in MainActivity and passing it to every screen instead of calling LocalContext.current to make code more readable and since I thought it might have caused issues with the recorder (it didn't in the end)
---

### **Files Changed**

1. **`AudioRecorder.kt`:**
   - Added a new method `startRecording(audioFile: File)` to allow saving files with a specific name.
   - Updated logging to verify successful file saving with the correct name.

2. **`SpeakingRepositoryRecord.kt`:**
   - Replaced the call to `startRecording()` with the new `startRecording(audioFile: File)` method.
   - Ensured that the passed file name is consistent across components.

3. **`SpeakingViewModel.kt`:**
   - Added support for passing a `File` object when starting or saving a recording.
   - Modified `onMicButtonClicked` to pass the correct file name to `SpeakingRepository`.

4. **`OfflineRecordingScreen.kt`:**
   - Updated the logic for initializing the file name (`{interviewPromptNb}.mp3`).
   - Passed the generated file name to the recording logic to ensure consistency.

5. **`RecordingReviewScreen.kt`:**
   - Ensured the correct file name is used when attempting to play back a recording.
   - Added logging to verify the playback file matches the saved file.

---

### **Outcome**
- Fixed crashes caused by file name mismatches during playback.
- Improved consistency in file naming across the app.
