### PR TITLE
fix: battle navigation

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt
@@ -49,26 +49,27 @@ class WaitingForCompletionScreenTest {
   private var battleUpdateCallback: ((SpeechBattle?) -> Unit)? = null
 
   private val testBattleId = "testBattleId"
-  private val testUserId = "testUser"
+  private val currentUserId = "testUser"
+  private val testFriendUid = "otherUser" // Added for clarity
 
   @Before
   fun setUp() {
     MockitoAnnotations.openMocks(this)
 
     // Mock getCurrentUserUid to return "testUser"
-    `when`(mockUserProfileRepository.getCurrentUserUid()).thenReturn(testUserId)
+    `when`(mockUserProfileRepository.getCurrentUserUid()).thenReturn(currentUserId)
 
     // Initialize ViewModels
     userProfileViewModel = UserProfileViewModel(mockUserProfileRepository)
     apiLinkViewModel = ApiLinkViewModel()
     chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel)
 
-    // Initial battle state: other user not completed yet.
+    // Initial battle state: friend has not completed yet.
     val initialBattle =
         SpeechBattle(
             battleId = testBattleId,
-            challenger = testUserId,
-            opponent = "otherUser",
+            challenger = currentUserId,
+            opponent = testFriendUid,
             status = BattleStatus.IN_PROGRESS,
             context =
                 InterviewContext(
@@ -79,7 +80,7 @@ class WaitingForCompletionScreenTest {
                     "testDescription",
                     "testFocusArea"),
             challengerCompleted = true, // Current user has completed
-            opponentCompleted = false // Other user has not yet completed
+            opponentCompleted = false // Friend has not yet completed
             )
 
     // Mock listenToBattleUpdates to capture the callback
@@ -93,10 +94,10 @@ class WaitingForCompletionScreenTest {
     }
 
     // Mock getUserProfile to return a valid user profile
-    `when`(mockUserProfileRepository.getUserProfile(eq("testUser"), any(), any())).thenAnswer {
+    `when`(mockUserProfileRepository.getUserProfile(eq(currentUserId), any(), any())).thenAnswer {
         invocation ->
       val onSuccess = invocation.getArgument<(UserProfile?) -> Unit>(1)
-      val userProfile = UserProfile("testUser", "Test User", 100, statistics = UserStatistics())
+      val userProfile = UserProfile(currentUserId, "Test User", 100, statistics = UserStatistics())
       onSuccess(userProfile)
       null
     }
@@ -106,14 +107,14 @@ class WaitingForCompletionScreenTest {
       val onSuccess = invocation.getArgument<(List<UserProfile>) -> Unit>(0)
       val profiles =
           listOf(
-              UserProfile("otherUser", "Other User", 100, statistics = UserStatistics()),
-              UserProfile("testUser", "Test User", 100, statistics = UserStatistics()))
+              UserProfile(testFriendUid, "Other User", 100, statistics = UserStatistics()),
+              UserProfile(currentUserId, "Test User", 100, statistics = UserStatistics()))
       onSuccess(profiles)
       null
     }
 
     // Initialize UserProfileViewModel
-    userProfileViewModel.getUserProfile("testUser")
+    userProfileViewModel.getUserProfile(currentUserId)
 
     // Initialize BattleViewModel
     battleViewModel =
@@ -136,7 +137,7 @@ class WaitingForCompletionScreenTest {
     composeTestRule.setContent {
       WaitingForCompletionScreen(
           battleId = testBattleId,
-          userId = testUserId,
+          friendUid = testFriendUid, // Corrected parameter
           navigationActions = mockNavigationActions,
           battleViewModel = battleViewModel)
     }
@@ -148,12 +149,12 @@ class WaitingForCompletionScreenTest {
     composeTestRule.onNodeWithTag("waitingText").assertIsDisplayed()
     composeTestRule.onNodeWithTag("loadingIndicator").assertIsDisplayed()
 
-    // No navigation should have happened yet since otherUser not completed
+    // No navigation should have happened yet since friend has not completed
     verify(mockNavigationActions, never()).navigateToEvaluationScreen(anyString())
   }
 
   /**
-   * Test navigation when the other user completes the battle. We simulate a battle update where the
+   * Test navigation when the friend completes the battle. We simulate a battle update where the
    * opponentCompleted is now true.
    */
   @Test
@@ -161,19 +162,19 @@ class WaitingForCompletionScreenTest {
     composeTestRule.setContent {
       WaitingForCompletionScreen(
           battleId = testBattleId,
-          userId = testUserId,
+          friendUid = testFriendUid, // Corrected parameter
           navigationActions = mockNavigationActions,
           battleViewModel = battleViewModel)
     }
 
     composeTestRule.waitForIdle()
 
-    // Simulate update: now the other user has completed
+    // Simulate update: now the friend has completed
     val updatedBattle =
         SpeechBattle(
             battleId = testBattleId,
-            challenger = testUserId,
-            opponent = "otherUser",
+            challenger = currentUserId,
+            opponent = testFriendUid,
             status = BattleStatus.IN_PROGRESS,
             context =
                 InterviewContext(
@@ -184,7 +185,7 @@ class WaitingForCompletionScreenTest {
                     "testDescription",
                     "testFocusArea"),
             challengerCompleted = true,
-            opponentCompleted = true // now other user completed
+            opponentCompleted = true // Friend has now completed
             )
 
     // Trigger the callback to simulate battle update

--- a/app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt
@@ -154,7 +154,7 @@ class WaitingForCompletionScreenTest {
   }
 
   /**
-   * Test navigation when the friend completes the battle. We simulate a battle update where the
+   * Test navigation when the other user completes the battle. We simulate a battle update where the
    * opponentCompleted is now true.
    */
   @Test

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -305,7 +305,7 @@ fun OratorApp(
               arguments =
                   listOf(
                       navArgument("battleId") { type = NavType.StringType },
-                      navArgument("userId") { type = NavType.StringType })) { backStackEntry ->
+                  )) { backStackEntry ->
                 val battleId = backStackEntry.arguments?.getString("battleId") ?: ""
                 val userId = userProfileViewModel.userProfile.value?.uid ?: ""
                 BattleChatScreen(
@@ -318,15 +318,18 @@ fun OratorApp(
               }
 
           composable(
-              route = "${Route.WAITING_FOR_COMPLETION}/{battleId}",
-              arguments = listOf(navArgument("battleId") { type = NavType.StringType })) {
-                  backStackEntry ->
+              route = "${Route.WAITING_FOR_COMPLETION}/{battleId}/{friendUid}",
+              arguments =
+                  listOf(
+                      navArgument("battleId") { type = NavType.StringType },
+                      navArgument("friendUid") { type = NavType.StringType })) { backStackEntry ->
                 val battleId = backStackEntry.arguments?.getString("battleId") ?: ""
+                val friendUid = backStackEntry.arguments?.getString("friendUid") ?: ""
                 WaitingForCompletionScreen(
+                    friendUid = friendUid,
                     battleId = battleId,
                     navigationActions = navigationActions,
-                    battleViewModel = battleViewModel,
-                    userId = userProfileViewModel.userProfile.value?.uid ?: "")
+                    battleViewModel = battleViewModel)
               }
           composable(
               route = "${Route.EVALUATION}/{battleId}",

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
@@ -201,7 +201,8 @@ class BattleViewModel(
               }
             } else {
               // Navigate to the waiting screen while waiting for the other user
-              navigationActions.navigateToWaitingForCompletion(battleId)
+              val friendUid = if (isChallenger) battle.opponent else battle.challenger
+              navigationActions.navigateToWaitingForCompletion(battleId, friendUid)
             }
           } else {
             Log.e("BattleViewModel", "Failed to retrieve battle for battleId: $battleId")

--- a/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
@@ -29,7 +29,7 @@ import com.github.se.orator.ui.theme.AppDimensions
 @Composable
 fun WaitingForCompletionScreen(
     battleId: String,
-    userId: String,
+    friendUid: String,
     navigationActions: NavigationActions,
     battleViewModel: BattleViewModel
 ) {
@@ -41,7 +41,7 @@ fun WaitingForCompletionScreen(
     battle?.let {
       // Check if the other user has completed
       val otherUserCompleted =
-          if (userId == it.challenger) it.opponentCompleted else it.challengerCompleted
+          if (friendUid == it.opponent) it.opponentCompleted else it.challengerCompleted
 
       if (otherUserCompleted) {
         // Navigate directly to the evaluation screen

--- a/app/src/main/java/com/github/se/orator/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/orator/ui/navigation/NavigationActions.kt
@@ -205,8 +205,8 @@ open class NavigationActions(
    *
    * @param battleId The ID of the battle.
    */
-  open fun navigateToWaitingForCompletion(battleId: String) {
-    navController.navigate("${Route.WAITING_FOR_COMPLETION}/$battleId")
+  open fun navigateToWaitingForCompletion(battleId: String, friendUid: String) {
+    navController.navigate("${Route.WAITING_FOR_COMPLETION}/$battleId/$friendUid")
   }
 
   /**


### PR DESCRIPTION
**Summary:**  
This PR introduces minor adjustments to the navigation flow between battle screens, preparing the codebase for an upcoming bug fix and future enhancements.

**Changed Files:**

1. **`WaitingForCompletionScreen.kt`**: Updated composable arguments to use `friendUid` instead of `userUid` to better support future features.
2. **`MainActivity.kt`**: Added necessary logic to pass updated arguments for navigation.
3. **`BattleViewModel.kt`**: Added a line to retrieve the `friendUid` to pass it as an argument before navigating to the waiting screen.
4. **`NavigationActions.kt`**: Adjusted navigation methods to align with updated navigation paths.
5. **`WaitingForCompletionScreenTest.kt`**: Updated test cases to match the new composable signature and ensure test integrity.