### PR TITLE
modify SpeakingPracticeModule UI

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/overview/SpeakingPublicSpeakingTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/overview/SpeakingPublicSpeakingTest.kt
@@ -125,7 +125,6 @@ class SpeakingPublicSpeakingTest {
 
     // topAppBar and screenTitle are likely at the top and may not need scrolling
     composeTestRule.onNodeWithTag("topAppBar", useUnmergedTree = true).assertIsDisplayed()
-    composeTestRule.onNodeWithTag("screenTitle", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithTag("content").assertIsDisplayed()
 
     // Verify back button and its functionality

--- a/app/src/androidTest/java/com/github/se/orator/ui/overview/SpeakingSalesPitchModuletest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/overview/SpeakingSalesPitchModuletest.kt
@@ -106,7 +106,6 @@ class SpeakingSalesPitchModuleTest {
 
     // topAppBar and screenTitle are likely at the top and may not need scrolling
     composeTestRule.onNodeWithTag("topAppBar", useUnmergedTree = true).assertIsDisplayed()
-    composeTestRule.onNodeWithTag("screenTitle", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithTag("content").assertIsDisplayed()
 
     // Verify back button and its functionality

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingJobInterviewModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingJobInterviewModule.kt
@@ -102,7 +102,6 @@ fun SpeakingJobInterviewModule(
    */
   SpeakingPracticeModule(
       navigationActions = navigationActions,
-      screenTitle = "Job Interview",
       headerText = "Ace your next job interview",
       inputs = inputFields,
       onClick = {

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
@@ -79,9 +79,8 @@ fun SpeakingPracticeModule(
                   }
             },
             colors =
-            TopAppBarDefaults.centerAlignedTopAppBarColors(
-                containerColor = MaterialTheme.colorScheme.surface
-            ))
+                TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface))
       },
       content = { paddingValues ->
         Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
@@ -43,7 +43,7 @@ import kotlin.math.roundToInt
 @Composable
 fun SpeakingPracticeModule(
     navigationActions: NavigationActions,
-    screenTitle: String,
+    screenTitle: String = "",
     headerText: String,
     inputs: List<InputFieldData>,
     onClick: () -> Unit,
@@ -79,9 +79,9 @@ fun SpeakingPracticeModule(
                   }
             },
             colors =
-                TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                    titleContentColor = MaterialTheme.colorScheme.onSurface))
+            TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ))
       },
       content = { paddingValues ->
         Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPublicSpeakingModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPublicSpeakingModule.kt
@@ -164,7 +164,6 @@ fun SpeakingPublicSpeakingModule(
    */
   SpeakingPracticeModule(
       navigationActions = navigationActions,
-      screenTitle = "Public Speaking",
       headerText = "Make your speech memorable",
       inputs = inputFields,
       onClick = {

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingSalesPitchModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingSalesPitchModule.kt
@@ -120,7 +120,6 @@ fun SpeakingSalesPitchModule(
    */
   SpeakingPracticeModule(
       navigationActions = navigationActions,
-      screenTitle = "Sales Pitch",
       headerText = "Master your sales pitch and negotiation skills",
       inputs = inputFields,
       onClick = {


### PR DESCRIPTION
This PR focuses on enhancing the UI of the speaking screens by removing unecessary screen titles and adapting it to Figma look. 
Quick preview of how it now looks like overall : 

Here's a Before :
![image](https://github.com/user-attachments/assets/a8481b49-8bff-43e3-a312-8ed182773246)

And an After : 
![image](https://github.com/user-attachments/assets/f13bb076-cca7-48e1-9cb9-cd2fe66a47e7)

Small fix - tell me what you think about it ! 