### PR TITLE
Feature : display friend name instead of other user in waiting for completion

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt
@@ -139,7 +139,8 @@ class WaitingForCompletionScreenTest {
           battleId = testBattleId,
           friendUid = testFriendUid, // Corrected parameter
           navigationActions = mockNavigationActions,
-          battleViewModel = battleViewModel)
+          battleViewModel = battleViewModel,
+          userProfileViewModel = userProfileViewModel)
     }
 
     composeTestRule.waitForIdle()
@@ -164,7 +165,8 @@ class WaitingForCompletionScreenTest {
           battleId = testBattleId,
           friendUid = testFriendUid, // Corrected parameter
           navigationActions = mockNavigationActions,
-          battleViewModel = battleViewModel)
+          battleViewModel = battleViewModel,
+          userProfileViewModel = userProfileViewModel)
     }
 
     composeTestRule.waitForIdle()

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -329,7 +329,8 @@ fun OratorApp(
                     friendUid = friendUid,
                     battleId = battleId,
                     navigationActions = navigationActions,
-                    battleViewModel = battleViewModel)
+                    battleViewModel = battleViewModel,
+                    userProfileViewModel = userProfileViewModel)
               }
           composable(
               route = "${Route.EVALUATION}/{battleId}",

--- a/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import com.github.se.orator.model.profile.UserProfileViewModel
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.ui.navigation.NavigationActions
 import com.github.se.orator.ui.theme.AppColors
@@ -31,10 +32,12 @@ fun WaitingForCompletionScreen(
     battleId: String,
     friendUid: String,
     navigationActions: NavigationActions,
-    battleViewModel: BattleViewModel
+    battleViewModel: BattleViewModel,
+    userProfileViewModel: UserProfileViewModel
 ) {
   // State to observe the battle status
   val battle by battleViewModel.getBattleByIdFlow(battleId).collectAsState(initial = null)
+  val friendName = userProfileViewModel.getName(friendUid)
 
   // LaunchedEffect to check both users' completion statuses and navigate accordingly
   LaunchedEffect(battle) {
@@ -64,7 +67,7 @@ fun WaitingForCompletionScreen(
                     .testTag("waitingForCompletionScreen"),
             horizontalAlignment = Alignment.CenterHorizontally) {
               Text(
-                  text = "You have completed your interview. Waiting for the other user to finish.",
+                  text = "You have completed your interview. Waiting for $friendName to finish.",
                   style = MaterialTheme.typography.bodyLarge,
                   textAlign = TextAlign.Center,
                   modifier =


### PR DESCRIPTION
As the title indicates, this PR introduces the necessary changes to display the friend's name instead of `other user` on the waiting for completion screen as requested by @charbelraffoul in #197. This closes #243

### Changed Files

1. **`app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt`**  
   - Modified to pass the user profile view model as an argument to fetch the friend's name using the friend's UID.

2. **`app/src/main/java/com/github/se/orator/MainActivity.kt`**  
   - Updated to pass the user profile view model to the Waiting for Completion screen.

3. **`app/src/androidTest/java/com/github/se/orator/ui/battle/WaitingForCompletionScreenTest.kt`**  
   - Updated the test to pass the user profile view model.

