### PR TITLE
Fix : BOTI dark mode integration

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -47,7 +47,6 @@ fun BattleRequestSentScreen(
     if (battleStatus == BattleStatus.IN_PROGRESS) {
       Log.d("BattleRequestSentScreen", "Battle in progress")
       // Navigate to the battle screen
-      // navigationActions.navigateToBattleScreen(battleId, friendUid)
       battleViewModel.startBattle(battleId)
     }
   }

--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -80,6 +80,7 @@ fun BattleRequestSentScreen(
                       "Interview Battle request has been successfully sent to $friendName.\nWaiting for $friendName to accept the battle.",
                   style = MaterialTheme.typography.bodyLarge,
                   textAlign = TextAlign.Center,
+                  color = MaterialTheme.colorScheme.onSurface,
                   modifier =
                       Modifier.padding(bottom = AppDimensions.paddingMedium)
                           .testTag("battleRequestSentText"))

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -17,13 +18,18 @@ import com.github.se.orator.ui.navigation.NavigationActions
 @Composable
 fun EvaluationScreen(battleId: String, navigationActions: NavigationActions) {
   Scaffold(
-      topBar = { TopAppBar(title = { Text("Evaluation in Progress") }) },
+      topBar = {
+        TopAppBar(
+            title = { Text("Evaluation in Progress", color = MaterialTheme.colorScheme.onSurface) })
+      },
       content = { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize().padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
-              Text("GPT is currently evaluating both answers")
+              Text(
+                  "GPT is currently evaluating both answers",
+                  color = MaterialTheme.colorScheme.onSurface)
             }
       })
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
@@ -56,7 +56,10 @@ fun WaitingForCompletionScreen(
   }
 
   Scaffold(
-      topBar = { TopAppBar(title = { Text("Waiting for Completion") }) },
+      topBar = {
+        TopAppBar(
+            title = { Text("Waiting for Completion", color = MaterialTheme.colorScheme.onSurface) })
+      },
       content = { innerPadding ->
         Column(
             modifier =
@@ -70,6 +73,7 @@ fun WaitingForCompletionScreen(
                   text = "You have completed your interview. Waiting for $friendName to finish.",
                   style = MaterialTheme.typography.bodyLarge,
                   textAlign = TextAlign.Center,
+                  color = MaterialTheme.colorScheme.onSurface,
                   modifier =
                       Modifier.padding(bottom = AppDimensions.paddingMedium).testTag("waitingText"))
 


### PR DESCRIPTION
This PR introduces dark mode support for the interview battle screens, specifically:  
- `BattleRequestSentScreen`  
- `EvaluationScreen`  
- `WaitingForCompletionScreen`  

Additionally, it removes an unused comment from the `BattleRequestSentScreen`.  It closes #270 