### PR TITLE
fix : inconsistencies in speaking practice module dark mode

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
@@ -117,7 +117,8 @@ fun SpeakingPracticeModule(
                         question = input.question,
                         placeholder = input.placeholder,
                         testTag = input.testTag,
-                        dropdownItems = input.dropdownItems,)
+                        dropdownItems = input.dropdownItems,
+                    )
                   } else {
                     // Display question as Text
                     Text(
@@ -227,6 +228,9 @@ fun SpeakingPracticeModule(
                                   unfocusedPlaceholderColor =
                                       MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                               ),
+                          textStyle =
+                              LocalTextStyle.current.copy(
+                                  color = MaterialTheme.colorScheme.onSurface),
                           keyboardOptions =
                               KeyboardOptions.Default.copy(imeAction = ImeAction.Next))
                     }
@@ -327,7 +331,7 @@ fun FocusAreaDropdown(
             modifier = Modifier.testTag("$testTag-DropdownMenu")) {
               dropdownItems.forEach { item ->
                 DropdownMenuItem(
-                    text = { Text(text = item,color = MaterialTheme.colorScheme.onSurface) },
+                    text = { Text(text = item, color = MaterialTheme.colorScheme.onSurface) },
                     onClick = {
                       onFocusAreaSelected(item)
                       expanded = false

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
@@ -117,7 +117,7 @@ fun SpeakingPracticeModule(
                         question = input.question,
                         placeholder = input.placeholder,
                         testTag = input.testTag,
-                        dropdownItems = input.dropdownItems)
+                        dropdownItems = input.dropdownItems,)
                   } else {
                     // Display question as Text
                     Text(
@@ -327,7 +327,7 @@ fun FocusAreaDropdown(
             modifier = Modifier.testTag("$testTag-DropdownMenu")) {
               dropdownItems.forEach { item ->
                 DropdownMenuItem(
-                    text = { Text(text = item) },
+                    text = { Text(text = item,color = MaterialTheme.colorScheme.onSurface) },
                     onClick = {
                       onFocusAreaSelected(item)
                       expanded = false


### PR DESCRIPTION
This PR fixes #276 by addressing the following inconsistencies in the **Speaking Practice Module**:

- Ensures the color of the dropdown menu item text aligns with the dark mode theme.
- Updates the input text color in text fields to be consistent with the dark mode theme.