### PR TITLE
Fix metric data storing

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestore.kt
@@ -2,6 +2,7 @@ package com.github.se.orator.model.profile
 
 import android.net.Uri
 import android.util.Log
+import com.github.se.orator.model.speaking.AnalysisData
 import com.github.se.orator.model.speaking.InterviewContext
 import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.SpeechBattle
@@ -16,6 +17,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Transaction
 import com.google.firebase.storage.FirebaseStorage
+import java.util.ArrayDeque
 import java.util.Date
 
 /**
@@ -248,6 +250,14 @@ class UserProfileRepositoryFirestore(private val db: FirebaseFirestore) : UserPr
             val successfulSessions =
                 successfulSessionsMap.mapValues { entry -> entry.value.toInt() }
 
+            // Extract 'recentData' queue
+            val recentData =
+                it["recentData"] as? kotlin.collections.ArrayDeque<AnalysisData>
+                    ?: kotlin.collections.ArrayDeque<AnalysisData>()
+            // Extract means
+            val talkTimeSecMean = (it["talkTimeSecMean"] as? Number)?.toDouble() ?: 0.0
+            val talkTimePercMean = (it["talkTimePercMean"] as? Number)?.toDouble() ?: 0.0
+
             // Extract 'previousRuns' list
             val previousRunsList = it["previousRuns"] as? List<Map<String, Any>>
             val previousRuns =
@@ -286,6 +296,9 @@ class UserProfileRepositoryFirestore(private val db: FirebaseFirestore) : UserPr
                 successfulSessions = successfulSessions,
                 improvement = improvement,
                 previousRuns = previousRuns,
+                recentData = recentData,
+                talkTimeSecMean = talkTimeSecMean,
+                talkTimePercMean = talkTimePercMean,
                 battleStats = battleStats)
           } ?: UserStatistics()
 

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
@@ -522,7 +522,7 @@ class UserProfileViewModel(internal val repository: UserProfileRepository) : Vie
         }
 
     // Update the MutableStateFlow with the new queue
-    queue.value = updatedQueue
+    recentData_.value = updatedQueue
 
     return updatedQueue
   }

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
@@ -541,7 +541,6 @@ class UserProfileViewModel(internal val repository: UserProfileRepository) : Vie
 
       // Create a new statistics object with the updated queue
       val updatedStats = currentStats.copy(recentData = updatedQueue)
-
       // Create a new profile object with the updated queue
       val updatedProfile = currentUserProfile.copy(statistics = updatedStats)
 

--- a/app/src/main/java/com/github/se/orator/model/speaking/AnalysisData.kt
+++ b/app/src/main/java/com/github/se/orator/model/speaking/AnalysisData.kt
@@ -21,14 +21,6 @@ data class AnalysisData(
       Log.e("AnalysisData", "Invalid transcription: cannot be blank.")
       return false
     }
-    if (fillerWordsCount < 0) {
-      Log.e("AnalysisData", "Invalid fillerWordsCount: cannot be negative.")
-      return false
-    }
-    if (averagePauseDuration < 0.0) {
-      Log.e("AnalysisData", "Invalid averagePauseDuration: cannot be negative.")
-      return false
-    }
     if (talkTimePercentage < 0.0 || talkTimePercentage > 100.0) {
       Log.e("AnalysisData", "Invalid talkTimePercentage: must be between 0 and 100.")
       return false

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingViewModel.kt
@@ -69,7 +69,7 @@ class SpeakingViewModel(
         repository.setupAnalysisResultsUsage(
             onSuccess = { ad ->
               _analysisData.value = ad
-              userProfileViewModel.addNewestData(ad)
+              userProfileViewModel.addNewestData(_analysisData.value!!)
               userProfileViewModel.updateMetricMean()
             },
             onFailure = { error -> _analysisError.value = error })


### PR DESCRIPTION
This PR is to resolve the problem with saving metric data in the firebase. The "recentData" queue wasn't updating and it was due to the "isValid" function that checks unused metrics and returning false for them.

Changes made
- Deleted the check for unused metrics
- Updated the documentToUserProfile function for it to handle recentData and the talkTimeSeconds/talkTimePercentage means

Related issues:
#273 