### PR TITLE
Add number of sessions and success on stat screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/profile/StatScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/profile/StatScreenTest.kt
@@ -2,6 +2,7 @@ package com.github.se.orator.ui.profile
 
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -55,7 +56,9 @@ class StatScreenTest {
               UserStatistics(
                   recentData = mockedRecentData,
                   talkTimeSecMean = talkTimeSecMean,
-                  talkTimePercMean = talkTimePercMean),
+                  talkTimePercMean = talkTimePercMean,
+                  sessionsGiven = mapOf("INTERVIEW" to 10, "SPEECH" to 5, "NEGOTIATION" to 8),
+                  successfulSessions = mapOf("INTERVIEW" to 7, "SPEECH" to 3, "NEGOTIATION" to 4)),
           friends = listOf("friend1", "friend2"),
           bio = "Test bio")
 
@@ -117,6 +120,70 @@ class StatScreenTest {
         .onNodeWithTag("talkTimePercMeanTitle")
         .assertIsDisplayed()
         .assert(hasText("Mean: ${talkTimePercMean}"))
+  }
+
+  @Test
+  fun testTitleAndStatsRow_InterviewSection_DisplayedCorrectly() {
+
+    // When the composable is shown
+    composeTestRule.setContent { TitleAndStatsRow(profile = testUserProfile) }
+
+    // Then check that Interview title and stats are displayed
+    composeTestRule
+        .onNodeWithTag("InterviewTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Interview")
+
+    composeTestRule
+        .onNodeWithTag("totalSessionsInterviewTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Sessions: 10")
+
+    composeTestRule
+        .onNodeWithTag("successSessionsInterviewTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Successful: 7")
+  }
+
+  @Test
+  fun testTitleAndStatsRow_SpeechSection_DisplayedCorrectly() {
+
+    composeTestRule.setContent { TitleAndStatsRow(profile = testUserProfile) }
+
+    // Check Speech section
+    composeTestRule.onNodeWithTag("speechTitle").assertIsDisplayed().assertTextEquals("Speech")
+
+    composeTestRule
+        .onNodeWithTag("totalSessionsSpeechTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Sessions: 5")
+
+    composeTestRule
+        .onNodeWithTag("successSessionsSpeechTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Successful: 3")
+  }
+
+  @Test
+  fun testTitleAndStatsRow_NegotiationSection_DisplayedCorrectly() {
+
+    composeTestRule.setContent { TitleAndStatsRow(profile = testUserProfile) }
+
+    // Check Negotiation section
+    composeTestRule
+        .onNodeWithTag("negotiationTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Negotiation")
+
+    composeTestRule
+        .onNodeWithTag("totalSessionsNegotiationTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Sessions: 8")
+
+    composeTestRule
+        .onNodeWithTag("successSessionsNegotiationTitle")
+        .assertIsDisplayed()
+        .assertTextEquals("Successful: 4")
   }
 }
 

--- a/app/src/androidTest/java/com/github/se/orator/ui/profile/StatScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/profile/StatScreenTest.kt
@@ -123,63 +123,43 @@ class StatScreenTest {
   }
 
   @Test
-  fun testTitleAndStatsRow_InterviewSection_DisplayedCorrectly() {
-
-    // When the composable is shown
+  fun titleAndStatsRow_displaysCorrectStats() {
     composeTestRule.setContent { TitleAndStatsRow(profile = testUserProfile) }
 
-    // Then check that Interview title and stats are displayed
+    // Check Interview Stats
     composeTestRule
         .onNodeWithTag("InterviewTitle")
         .assertIsDisplayed()
         .assertTextEquals("Interview")
-
     composeTestRule
         .onNodeWithTag("totalSessionsInterviewTitle")
         .assertIsDisplayed()
         .assertTextEquals("Sessions: 10")
-
     composeTestRule
         .onNodeWithTag("successSessionsInterviewTitle")
         .assertIsDisplayed()
         .assertTextEquals("Successful: 7")
-  }
 
-  @Test
-  fun testTitleAndStatsRow_SpeechSection_DisplayedCorrectly() {
-
-    composeTestRule.setContent { TitleAndStatsRow(profile = testUserProfile) }
-
-    // Check Speech section
-    composeTestRule.onNodeWithTag("speechTitle").assertIsDisplayed().assertTextEquals("Speech")
-
+    // Check Speech Stats
+    composeTestRule.onNodeWithTag("SpeechTitle").assertIsDisplayed().assertTextEquals("Speech")
     composeTestRule
         .onNodeWithTag("totalSessionsSpeechTitle")
         .assertIsDisplayed()
         .assertTextEquals("Sessions: 5")
-
     composeTestRule
         .onNodeWithTag("successSessionsSpeechTitle")
         .assertIsDisplayed()
         .assertTextEquals("Successful: 3")
-  }
 
-  @Test
-  fun testTitleAndStatsRow_NegotiationSection_DisplayedCorrectly() {
-
-    composeTestRule.setContent { TitleAndStatsRow(profile = testUserProfile) }
-
-    // Check Negotiation section
+    // Check Negotiation Stats
     composeTestRule
-        .onNodeWithTag("negotiationTitle")
+        .onNodeWithTag("NegotiationTitle")
         .assertIsDisplayed()
         .assertTextEquals("Negotiation")
-
     composeTestRule
         .onNodeWithTag("totalSessionsNegotiationTitle")
         .assertIsDisplayed()
         .assertTextEquals("Sessions: 8")
-
     composeTestRule
         .onNodeWithTag("successSessionsNegotiationTitle")
         .assertIsDisplayed()

--- a/app/src/main/java/com/github/se/orator/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/ProfileScreen.kt
@@ -238,7 +238,6 @@ fun ProfileScreen(navigationActions: NavigationActions, profileViewModel: UserPr
 
                 Spacer(modifier = Modifier.height(AppDimensions.paddingMedium))
                 Log.d("scn", "bio is: ${profile.bio}")
-
                 // stats section
                 CardSection(
                     title = "My stats",

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -2,9 +2,11 @@ package com.github.se.orator.ui.profile
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -74,7 +76,7 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                         .testTag("graphScreenTitle"),
                 text = "Statistics Graph",
                 style = AppTypography.mediumTitleStyle, // Apply custom style for title
-                color = MaterialTheme.colorScheme.onSurface)
+                color = MaterialTheme.colorScheme.primary)
 
             Text(
                 modifier =
@@ -159,6 +161,46 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                         color = MaterialTheme.colorScheme.onSurface)
                   }
             }
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth().padding(horizontal = AppDimensions.paddingMedium),
+                horizontalArrangement = Arrangement.SpaceEvenly) {
+                  Column {
+                    PracticeModeTitle("InterviewTitle", "Interview")
+                    StatDisplay(
+                        "totalSessionsInterviewTitle",
+                        "Sessions: ",
+                        "${profile.statistics.sessionsGiven["INTERVIEW"]}")
+                    StatDisplay(
+                        "successSessionsInterviewTitle",
+                        "Successful: ",
+                        "${profile.statistics.successfulSessions["INTERVIEW"]}")
+                  }
+
+                  Column {
+                    PracticeModeTitle("speechTitle", "Speech")
+                    StatDisplay(
+                        "totalSessionsSpeechTitle",
+                        "Sessions: ",
+                        "${profile.statistics.sessionsGiven["SPEECH"]}")
+                    StatDisplay(
+                        "successSessionsSpeechTitle",
+                        "Successful: ",
+                        "${profile.statistics.successfulSessions["SPEECH"]}")
+                  }
+
+                  Column {
+                    PracticeModeTitle("negotiationTitle", "Negotiation")
+                    StatDisplay(
+                        "totalSessionsNegotiationTitle",
+                        "Sessions: ",
+                        "${profile.statistics.sessionsGiven["NEGOTIATION"]}")
+                    StatDisplay(
+                        "successSessionsNegotiationTitle",
+                        "Successful: ",
+                        "${profile.statistics.successfulSessions["NEGOTIATION"]}")
+                  }
+                }
           }
         }
       },
@@ -252,4 +294,30 @@ fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String) {
               )
         }
       }
+}
+
+/** Composable for practice mode title displays on the stats screen */
+@Composable
+fun PracticeModeTitle(modeTitleTEstTag: String, mode: String) {
+  androidx.compose.material3.Text(
+      modifier =
+          Modifier.padding(start = AppDimensions.paddingSmall)
+              .padding(top = AppDimensions.paddingXXLarge)
+              .testTag(modeTitleTEstTag),
+      text = mode,
+      style = AppTypography.smallTitleStyle, // Apply custom style for title
+      color = MaterialTheme.colorScheme.primary)
+}
+
+/** Composable for stats displays on the stats screen */
+@Composable
+fun StatDisplay(statTestTag: String, stat: String, statValue: String) {
+  androidx.compose.material3.Text(
+      modifier =
+          Modifier.padding(start = AppDimensions.paddingSmall)
+              .padding(top = AppDimensions.paddingSmall)
+              .testTag(statTestTag),
+      text = stat + statValue,
+      style = AppTypography.xSmallTitleStyle, // Apply custom style for title
+      color = MaterialTheme.colorScheme.onSurface)
 }

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -284,9 +284,7 @@ fun StatDisplay(statTestTag: String, stat: String, statValue: String) {
       color = MaterialTheme.colorScheme.onSurface)
 }
 
-/**
- * Row that contains the titles and stats for each mode, side by side
- */
+/** Row that contains the titles and stats for each mode, side by side */
 @Composable
 fun TitleAndStatsRow(profile: UserProfile) {
   Row(

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -260,12 +260,12 @@ fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String) {
 
 /** Composable for practice mode title displays on the stats screen */
 @Composable
-fun PracticeModeTitle(modeTitleTEstTag: String, mode: String) {
+fun PracticeModeTitle(modeTitleTestTag: String, mode: String) {
   androidx.compose.material3.Text(
       modifier =
           Modifier.padding(start = AppDimensions.paddingSmall)
               .padding(top = AppDimensions.paddingXXLarge)
-              .testTag(modeTitleTEstTag),
+              .testTag(modeTitleTestTag),
       text = mode,
       style = AppTypography.smallTitleStyle, // Apply custom style for title
       color = MaterialTheme.colorScheme.primary)
@@ -284,46 +284,30 @@ fun StatDisplay(statTestTag: String, stat: String, statValue: String) {
       color = MaterialTheme.colorScheme.onSurface)
 }
 
+/** Composable for a single mode's stats and title */
+@Composable
+fun ModeStatsColumn(titleTestTag: String, mode: String, profile: UserProfile) {
+  val modeKey = mode.uppercase()
+  Column {
+    PracticeModeTitle(titleTestTag, mode)
+    StatDisplay(
+        statTestTag = "totalSessions${mode}Title",
+        stat = "Sessions: ",
+        statValue = profile.statistics.sessionsGiven[modeKey]?.toString() ?: "0")
+    StatDisplay(
+        statTestTag = "successSessions${mode}Title",
+        stat = "Successful: ",
+        statValue = profile.statistics.successfulSessions[modeKey]?.toString() ?: "0")
+  }
+}
 /** Row that contains the titles and stats for each mode, side by side */
 @Composable
 fun TitleAndStatsRow(profile: UserProfile) {
   Row(
       modifier = Modifier.fillMaxWidth().padding(horizontal = AppDimensions.paddingMedium),
       horizontalArrangement = Arrangement.SpaceEvenly) {
-        Column {
-          PracticeModeTitle("InterviewTitle", "Interview")
-          StatDisplay(
-              "totalSessionsInterviewTitle",
-              "Sessions: ",
-              "${profile.statistics.sessionsGiven["INTERVIEW"]}")
-          StatDisplay(
-              "successSessionsInterviewTitle",
-              "Successful: ",
-              "${profile.statistics.successfulSessions["INTERVIEW"]}")
-        }
-
-        Column {
-          PracticeModeTitle("speechTitle", "Speech")
-          StatDisplay(
-              "totalSessionsSpeechTitle",
-              "Sessions: ",
-              "${profile.statistics.sessionsGiven["SPEECH"]}")
-          StatDisplay(
-              "successSessionsSpeechTitle",
-              "Successful: ",
-              "${profile.statistics.successfulSessions["SPEECH"]}")
-        }
-
-        Column {
-          PracticeModeTitle("negotiationTitle", "Negotiation")
-          StatDisplay(
-              "totalSessionsNegotiationTitle",
-              "Sessions: ",
-              "${profile.statistics.sessionsGiven["NEGOTIATION"]}")
-          StatDisplay(
-              "successSessionsNegotiationTitle",
-              "Successful: ",
-              "${profile.statistics.successfulSessions["NEGOTIATION"]}")
-        }
+        ModeStatsColumn("InterviewTitle", "Interview", profile)
+        ModeStatsColumn("SpeechTitle", "Speech", profile)
+        ModeStatsColumn("NegotiationTitle", "Negotiation", profile)
       }
 }

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.platform.testTag
+import com.github.se.orator.model.profile.UserProfile
 import com.github.se.orator.model.profile.UserProfileViewModel
 import com.github.se.orator.ui.friends.TitleAppBar
 import com.github.se.orator.ui.navigation.BottomNavigationMenu
@@ -161,46 +162,7 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                         color = MaterialTheme.colorScheme.onSurface)
                   }
             }
-            Row(
-                modifier =
-                    Modifier.fillMaxWidth().padding(horizontal = AppDimensions.paddingMedium),
-                horizontalArrangement = Arrangement.SpaceEvenly) {
-                  Column {
-                    PracticeModeTitle("InterviewTitle", "Interview")
-                    StatDisplay(
-                        "totalSessionsInterviewTitle",
-                        "Sessions: ",
-                        "${profile.statistics.sessionsGiven["INTERVIEW"]}")
-                    StatDisplay(
-                        "successSessionsInterviewTitle",
-                        "Successful: ",
-                        "${profile.statistics.successfulSessions["INTERVIEW"]}")
-                  }
-
-                  Column {
-                    PracticeModeTitle("speechTitle", "Speech")
-                    StatDisplay(
-                        "totalSessionsSpeechTitle",
-                        "Sessions: ",
-                        "${profile.statistics.sessionsGiven["SPEECH"]}")
-                    StatDisplay(
-                        "successSessionsSpeechTitle",
-                        "Successful: ",
-                        "${profile.statistics.successfulSessions["SPEECH"]}")
-                  }
-
-                  Column {
-                    PracticeModeTitle("negotiationTitle", "Negotiation")
-                    StatDisplay(
-                        "totalSessionsNegotiationTitle",
-                        "Sessions: ",
-                        "${profile.statistics.sessionsGiven["NEGOTIATION"]}")
-                    StatDisplay(
-                        "successSessionsNegotiationTitle",
-                        "Successful: ",
-                        "${profile.statistics.successfulSessions["NEGOTIATION"]}")
-                  }
-                }
+            TitleAndStatsRow(profile)
           }
         }
       },
@@ -320,4 +282,50 @@ fun StatDisplay(statTestTag: String, stat: String, statValue: String) {
       text = stat + statValue,
       style = AppTypography.xSmallTitleStyle, // Apply custom style for title
       color = MaterialTheme.colorScheme.onSurface)
+}
+
+/**
+ * Row that contains the titles and stats for each mode, side by side
+ */
+@Composable
+fun TitleAndStatsRow(profile: UserProfile) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = AppDimensions.paddingMedium),
+      horizontalArrangement = Arrangement.SpaceEvenly) {
+        Column {
+          PracticeModeTitle("InterviewTitle", "Interview")
+          StatDisplay(
+              "totalSessionsInterviewTitle",
+              "Sessions: ",
+              "${profile.statistics.sessionsGiven["INTERVIEW"]}")
+          StatDisplay(
+              "successSessionsInterviewTitle",
+              "Successful: ",
+              "${profile.statistics.successfulSessions["INTERVIEW"]}")
+        }
+
+        Column {
+          PracticeModeTitle("speechTitle", "Speech")
+          StatDisplay(
+              "totalSessionsSpeechTitle",
+              "Sessions: ",
+              "${profile.statistics.sessionsGiven["SPEECH"]}")
+          StatDisplay(
+              "successSessionsSpeechTitle",
+              "Successful: ",
+              "${profile.statistics.successfulSessions["SPEECH"]}")
+        }
+
+        Column {
+          PracticeModeTitle("negotiationTitle", "Negotiation")
+          StatDisplay(
+              "totalSessionsNegotiationTitle",
+              "Sessions: ",
+              "${profile.statistics.sessionsGiven["NEGOTIATION"]}")
+          StatDisplay(
+              "successSessionsNegotiationTitle",
+              "Successful: ",
+              "${profile.statistics.successfulSessions["NEGOTIATION"]}")
+        }
+      }
 }


### PR DESCRIPTION
This pull request introduces the ability to display the number of sessions and successful attempts for the three practice modes (Interview, Speech, Negotiation) on the profile statistics screen. Additionally, it includes comprehensive UI tests that verify the correct display of these stats on the screen.

Stats addition in StatScreen:

- Added two new composables PracticeModeTitle and StatDisplay for practice mode titles and stats sessionsGiven and successfulSessions (with their values retrieved from the profile's stats) display 
- Added a new TitleAndStatsRow composable to display the stats for each practice mode side by side.
- Replace the color for the "Statitstics Graph" title to the primary color of the app (better looking)
- Made it adaptable to dark mode theme

UI Tests:

- Implemented UI tests to ensure that each mode (Interview, Speech, Negotiation) displays the correct titles and numeric values for “Sessions” and “Successful” sessions.
- Verified that all new UI elements are properly shown on the screen and match the expected text, enhancing confidence in the changes.

Files changed:
- StatScreen.kt
- StatScreenTest.kt

Screenshots/Previews:
<img width="257" alt="updStatScreen" src="https://github.com/user-attachments/assets/fb8ade2c-761c-4519-9d8f-af1eca493a72" />

Related issues:
#274 

These changes improve the user experience by providing clear, easily interpretable statistics on user performance across different practice modes.