### PR TITLE
feature: BOTI evaluation implementation

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/battle/EvaluationScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/battle/EvaluationScreenTest.kt
@@ -2,12 +2,29 @@ package com.github.se.orator.ui.battle
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.se.orator.model.apiLink.ApiLinkViewModel
+import com.github.se.orator.model.chatGPT.ChatViewModel
+import com.github.se.orator.model.profile.UserProfileRepository
+import com.github.se.orator.model.profile.UserProfileViewModel
+import com.github.se.orator.model.speaking.InterviewContext
+import com.github.se.orator.model.speechBattle.*
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.Screen
+import com.github.se.orator.ui.network.ChatGPTService
+import com.github.se.orator.ui.network.Message
+import com.google.firebase.firestore.ListenerRegistration
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 
 class EvaluationScreenTest {
 
@@ -15,18 +32,355 @@ class EvaluationScreenTest {
 
   @Mock private lateinit var mockNavigationActions: NavigationActions
 
-  @Test
-  fun evaluationScreenDisplaysCorrectly() {
+  @Mock private lateinit var mockBattleRepository: BattleRepository
+
+  @Mock private lateinit var mockUserProfileRepository: UserProfileRepository
+
+  @Mock private lateinit var mockChatGPTService: ChatGPTService
+
+  @Mock private lateinit var mockListenerRegistration: ListenerRegistration
+
+  private lateinit var userProfileViewModel: UserProfileViewModel
+  private lateinit var battleViewModel: BattleViewModel
+  private lateinit var apiLinkViewModel: ApiLinkViewModel
+  private lateinit var chatViewModel: ChatViewModel
+
+  // Constants for testing
+  private val currentUserId = "testUserId"
+  private val testFriendUid = "friendUid"
+  private val testBattleId = "testBattleId"
+
+  // Variable to capture the battle update callback
+  private var battleUpdateCallback: ((SpeechBattle?) -> Unit)? = null
+
+  @Before
+  fun setUp() {
     MockitoAnnotations.openMocks(this)
 
+    // Mock getCurrentUserUid to return "testUserId"
+    `when`(mockUserProfileRepository.getCurrentUserUid()).thenReturn(currentUserId)
+
+    // Initialize ViewModels
+    userProfileViewModel = UserProfileViewModel(mockUserProfileRepository)
+    apiLinkViewModel = ApiLinkViewModel()
+    chatViewModel = ChatViewModel(mockChatGPTService, apiLinkViewModel)
+    battleViewModel =
+        BattleViewModel(
+            battleRepository = mockBattleRepository,
+            userProfileViewModel = userProfileViewModel,
+            navigationActions = mockNavigationActions,
+            apiLinkViewModel = apiLinkViewModel,
+            chatViewModel = chatViewModel)
+
+    // Mock listenToBattleUpdates to capture the callback and return mock ListenerRegistration
+    `when`(mockBattleRepository.listenToBattleUpdates(eq(testBattleId), any())).thenAnswer {
+        invocation ->
+      val callback = invocation.getArgument<(SpeechBattle?) -> Unit>(1)
+      battleUpdateCallback = callback
+      mockListenerRegistration
+    }
+  }
+
+  @After
+  fun tearDown() {
+    mockListenerRegistration.remove()
+  }
+
+  /** Helper function to create a mock SpeechBattle. */
+  private fun createMockBattle(
+      status: BattleStatus,
+      evaluationResult: EvaluationResult? = null,
+      userId: String,
+      challengerUid: String = "challengerUid",
+      opponentUid: String = "opponentUid"
+  ): SpeechBattle {
+    return SpeechBattle(
+        battleId = testBattleId,
+        challenger = challengerUid,
+        opponent = opponentUid,
+        status = status,
+        context = getMockInterviewContext(),
+        evaluationResult = evaluationResult,
+        challengerCompleted = status != BattleStatus.EVALUATING,
+        opponentCompleted = status != BattleStatus.EVALUATING)
+  }
+
+  /** Helper function to create a mock InterviewContext. */
+  private fun getMockInterviewContext(): InterviewContext {
+    return InterviewContext(
+        targetPosition = "Software Engineer",
+        companyName = "Tech Corp",
+        interviewType = "Phone Interview",
+        experienceLevel = "Mid-Level",
+        jobDescription = "Develop and maintain software applications.",
+        focusArea = "Technical Questions")
+  }
+
+  /** Test that the EvaluationScreen shows loading when battle is null. */
+  @Test
+  fun evaluationScreen_ShowsLoadingState_WhenBattleIsNull() {
+    // Arrange
+    // No battle is emitted, initial state is null
+
+    // Act
     composeTestRule.setContent {
-      EvaluationScreen(battleId = "testBattleId", navigationActions = mockNavigationActions)
+      EvaluationScreen(
+          userId = currentUserId,
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
     }
 
-    // Assert that the top app bar title is displayed
-    composeTestRule.onNodeWithText("Evaluation in Progress").assertIsDisplayed()
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
 
-    // Assert that the evaluation message is displayed
-    composeTestRule.onNodeWithText("GPT is currently evaluating both answers").assertIsDisplayed()
+    // Verify that listenToBattleUpdates was called with the correct battleId
+    verify(mockBattleRepository).listenToBattleUpdates(eq(testBattleId), any())
+
+    // Assert
+    composeTestRule.onNodeWithText("Loading battle data...").assertIsDisplayed()
+  }
+
+  /** Test that the EvaluationScreen shows evaluating state correctly. */
+  @Test
+  fun evaluationScreen_ShowsEvaluatingState_WhenBattleIsEvaluating() {
+    // Arrange
+    val evaluatingBattle =
+        createMockBattle(
+            status = BattleStatus.EVALUATING,
+            evaluationResult = null,
+            userId = currentUserId,
+            challengerUid = currentUserId,
+            opponentUid = testFriendUid)
+
+    // Act
+    composeTestRule.setContent {
+      EvaluationScreen(
+          userId = currentUserId,
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
+    }
+
+    // Emit the evaluating battle via battleUpdateCallback
+    battleUpdateCallback?.invoke(evaluatingBattle)
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Assert
+    composeTestRule.onNodeWithTag("loadingIndicator").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText("Evaluating performance and determining the winner")
+        .assertIsDisplayed()
+  }
+
+  /** Test that the EvaluationScreen shows completed state for winner correctly. */
+  @Test
+  fun evaluationScreen_ShowsCompletedState_Winner() {
+    // Arrange
+    val evaluationResult =
+        EvaluationResult(
+            winnerUid = currentUserId,
+            winnerMessage = Message(content = "Great job!", role = "assistant"),
+            loserMessage = Message(content = "Better luck next time.", role = "assistant"))
+    val completedBattle =
+        createMockBattle(
+            status = BattleStatus.COMPLETED,
+            evaluationResult = evaluationResult,
+            userId = currentUserId,
+            challengerUid = "challengerUid",
+            opponentUid = currentUserId)
+
+    // Act
+    composeTestRule.setContent {
+      EvaluationScreen(
+          userId = currentUserId,
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
+    }
+
+    // Emit the completed battle via battleUpdateCallback
+    battleUpdateCallback?.invoke(completedBattle)
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Assert
+    composeTestRule.onNodeWithText("You Won!").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Great job!").assertIsDisplayed()
+
+    // Verify that action buttons are displayed
+    composeTestRule.onNodeWithText("Retry").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Go to Practice").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Return to Home").assertIsDisplayed()
+  }
+
+  /** Test that the EvaluationScreen shows completed state for loser correctly. */
+  @Test
+  fun evaluationScreen_ShowsCompletedState_Loser() {
+    // Arrange
+    val evaluationResult =
+        EvaluationResult(
+            winnerUid = "challengerUid",
+            winnerMessage = Message(content = "Great job!", role = "assistant"),
+            loserMessage = Message(content = "Better luck next time.", role = "assistant"))
+    val completedBattle =
+        createMockBattle(
+            status = BattleStatus.COMPLETED,
+            evaluationResult = evaluationResult,
+            userId = "testUserId",
+            challengerUid = "testUserId",
+            opponentUid = "opponentUid")
+
+    // Act
+    composeTestRule.setContent {
+      EvaluationScreen(
+          userId = "testUserId",
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
+    }
+
+    // Emit the completed battle via battleUpdateCallback
+    battleUpdateCallback?.invoke(completedBattle)
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Assert
+    composeTestRule.onNodeWithText("You Lost.").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Better luck next time.").assertIsDisplayed()
+
+    // Verify that action buttons are displayed
+    composeTestRule.onNodeWithText("Retry").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Go to Practice").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Return to Home").assertIsDisplayed()
+  }
+
+  /**
+   * Test that the EvaluationScreen shows processing state when evaluationResult is null but status
+   * is COMPLETED.
+   */
+  @Test
+  fun evaluationScreen_ShowsProcessingState_WhenEvaluationResultIsNull() {
+    // Arrange
+    val completedBattle =
+        createMockBattle(
+            status = BattleStatus.COMPLETED,
+            evaluationResult = null,
+            userId = currentUserId,
+            challengerUid = "challengerUid",
+            opponentUid = currentUserId)
+
+    // Act
+    composeTestRule.setContent {
+      EvaluationScreen(
+          userId = currentUserId,
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
+    }
+
+    // Emit the completed battle via battleUpdateCallback
+    battleUpdateCallback?.invoke(completedBattle)
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Assert
+    composeTestRule.onNodeWithText("Processing results...").assertIsDisplayed()
+  }
+
+  /** Test clicking the "Go to Practice" button navigates correctly and calls reset functions. */
+  @Test
+  fun evaluationScreen_ClickGoToPractice_NavigatesCorrectly() {
+    // Arrange
+    val evaluationResult =
+        EvaluationResult(
+            winnerUid = currentUserId,
+            winnerMessage = Message(content = "Great job!", role = "assistant"),
+            loserMessage = Message(content = "Better luck next time.", role = "assistant"))
+    val completedBattle =
+        createMockBattle(
+            status = BattleStatus.COMPLETED,
+            evaluationResult = evaluationResult,
+            userId = currentUserId,
+            challengerUid = "challengerUid",
+            opponentUid = currentUserId)
+
+    // Act
+    composeTestRule.setContent {
+      EvaluationScreen(
+          userId = currentUserId,
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
+    }
+
+    // Emit the completed battle via battleUpdateCallback
+    battleUpdateCallback?.invoke(completedBattle)
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Assert buttons are displayed
+    composeTestRule.onNodeWithText("Go to Practice").assertIsDisplayed()
+
+    // Perform click on "Go to Practice" button
+    composeTestRule.onNodeWithText("Go to Practice").performClick()
+
+    // Verify navigation to Speaking Job Interview
+    verify(mockNavigationActions).navigateTo(Screen.SPEAKING_JOB_INTERVIEW)
+  }
+
+  /** Test clicking the "Return to Home" button navigates correctly and calls reset functions. */
+  @Test
+  fun evaluationScreen_ClickReturnToHome_NavigatesCorrectly() {
+    // Arrange
+    val evaluationResult =
+        EvaluationResult(
+            winnerUid = currentUserId,
+            winnerMessage = Message(content = "Great job!", role = "assistant"),
+            loserMessage = Message(content = "Better luck next time.", role = "assistant"))
+    val completedBattle =
+        createMockBattle(
+            status = BattleStatus.COMPLETED,
+            evaluationResult = evaluationResult,
+            userId = currentUserId,
+            challengerUid = "challengerUid",
+            opponentUid = currentUserId)
+
+    // Act
+    composeTestRule.setContent {
+      EvaluationScreen(
+          userId = currentUserId,
+          battleId = testBattleId,
+          navigationActions = mockNavigationActions,
+          battleViewModel = battleViewModel,
+          chatViewModel = chatViewModel)
+    }
+
+    // Emit the completed battle via battleUpdateCallback
+    battleUpdateCallback?.invoke(completedBattle)
+
+    // Wait for the UI to update
+    composeTestRule.waitForIdle()
+
+    // Assert buttons are displayed
+    composeTestRule.onNodeWithText("Return to Home").assertIsDisplayed()
+
+    // Perform click on "Return to Home" button
+    composeTestRule.onNodeWithText("Return to Home").performClick()
+
+    // Verify navigation to Home
+    verify(mockNavigationActions).navigateTo(Screen.HOME)
   }
 }

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -339,7 +339,12 @@ fun OratorApp(
               arguments = listOf(navArgument("battleId") { type = NavType.StringType })) {
                   backStackEntry ->
                 val battleId = backStackEntry.arguments?.getString("battleId") ?: ""
-                EvaluationScreen(battleId = battleId, navigationActions = navigationActions)
+                val userId = userProfileViewModel.userProfile.value?.uid ?: ""
+                EvaluationScreen(
+                    userId = userId,
+                    battleId = battleId,
+                    navigationActions = navigationActions,
+                    battleViewModel = battleViewModel)
               }
         }
 

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -344,7 +344,8 @@ fun OratorApp(
                     userId = userId,
                     battleId = battleId,
                     navigationActions = navigationActions,
-                    battleViewModel = battleViewModel)
+                    battleViewModel = battleViewModel,
+                    chatViewModel = chatViewModel)
               }
         }
 

--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -565,13 +565,14 @@ The session is now over. According to the initial instructions, you can now brea
         Then, provide a message addressed to the winner, highlighting why they won (max one paragraph). 
         Also, provide a message addressed to the loser, highlighting what they did wrong and where they can improve (max one paragraph).
         For both messages focus on the quality of the answers, clarity, and overall performance.
+        Address both users as you so that we can directly display the feedback message on their screens.
         Don't over compliment the winner because he might have also made mistakes, make sure to stay neutral and professional: a strict interviewer. 
         
 
         Format your answer as:
         The winner is: <winnerUid>
         Winner message: <short message>
-        Loser message: <short message>
+        Loser message: <short message> 
         """
 
     val request =

--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -542,7 +542,9 @@ The session is now over. According to the initial instructions, you can now brea
       user1Uid: String,
       user2Uid: String,
       user1messages: List<Message>,
-      user2messages: List<Message>
+      user2messages: List<Message>,
+      user1name: String,
+      user2name: String
   ): EvaluationResult {
     val user1Transcript = messagesToTranscript(user1Uid, user1messages)
     val user2Transcript = messagesToTranscript(user2Uid, user2messages)
@@ -562,8 +564,8 @@ The session is now over. According to the initial instructions, you can now brea
         Please determine who performed better and explicitly state: "The winner is $user1Uid" or "The winner is $user2Uid".
         Then, provide a message addressed to the winner, highlighting why they won (max one paragraph). 
         Also, provide a message addressed to the loser, highlighting what they did wrong and where they can improve (max one paragraph).
-        For both messages focus on the quality of the answers, clarity, and overall performance. And address both users as "you". 
-        Don't over compliment the winner because he might have also made mistakes, make sure to stay neutral and professional. 
+        For both messages focus on the quality of the answers, clarity, and overall performance.
+        Don't over compliment the winner because he might have also made mistakes, make sure to stay neutral and professional: a strict interviewer. 
         
 
         Format your answer as:
@@ -606,11 +608,25 @@ The session is now over. According to the initial instructions, you can now brea
     val loserMessageText =
         loserMessageRegex.find(content)?.groups?.get(1)?.value?.trim() ?: "No loser message found."
 
+    // Create a map of UIDs to names
+    val uidToNameMap = mapOf(user1Uid to user1name, user2Uid to user2name)
+
+    // Replace UIDs in the messages
+    val updatedWinnerMessageText = replaceUidsWithNames(winnerMessageText, uidToNameMap)
+    val updatedLoserMessageText = replaceUidsWithNames(loserMessageText, uidToNameMap)
+
     // Create Message objects for winnerMessage and loserMessage
-    val winnerMessage = Message(role = "assistant", content = winnerMessageText)
-    val loserMessage = Message(role = "assistant", content = loserMessageText)
+    val winnerMessage = Message(role = "assistant", content = updatedWinnerMessageText)
+    val loserMessage = Message(role = "assistant", content = updatedLoserMessageText)
 
     return EvaluationResult(
         winnerUid = winnerUid, winnerMessage = winnerMessage, loserMessage = loserMessage)
+  }
+
+  // Helper function to replace UIDs with real names
+  private fun replaceUidsWithNames(message: String, uidToNameMap: Map<String, String>): String {
+    var updatedMessage = message
+    uidToNameMap.forEach { (uid, name) -> updatedMessage = updatedMessage.replace(uid, name) }
+    return updatedMessage
   }
 }

--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -551,29 +551,63 @@ The session is now over. According to the initial instructions, you can now brea
 
     val prompt =
         """
-        You are simulating a highly strict recruiter deciding between two candidates, $user1Uid and $user2Uid.
-        
-        You have all their Q&A transcripts:
-        
-        $user1Uid's transcript:
-        $user1Transcript
+        You are an impartial and strict recruiter tasked with evaluating two AI interview candidates, $user1Uid and $user2Uid, based on their interview transcripts. Your goal is to determine which AI performed better and provide constructive feedback for both.
 
-        $user2Uid's transcript:
-        $user2Transcript
+      **Guidelines:**
 
-        Please determine who performed better and explicitly state: "The winner is $user1Uid" or "The winner is $user2Uid".
-        Then, provide a message addressed to the winner, highlighting why they won (max one paragraph). 
-        Also, provide a message addressed to the loser, highlighting what they did wrong and where they can improve (max one paragraph).
-        For both messages focus on the quality of the answers, clarity, and overall performance.
-        Address both users as you so that we can directly display the feedback message on their screens.
-        Don't over compliment the winner because he might have also made mistakes, make sure to stay neutral and professional: a strict interviewer. 
-        
+      1. **Evaluation Criteria:**
+      - **Clarity and Coherence:** Assess how clearly and logically each AI communicated their answers.
+      - **Depth of Responses:** Evaluate the thoroughness and depth of each AI's answers.
+      - **Relevance to Questions:** Determine how well each AI addressed the interview questions.
+      - **Problem-Solving Ability:** Analyze the effectiveness of each AI's problem-solving approach.
+      - **Professionalism:** Consider the professionalism displayed in each AI's responses.
 
-        Format your answer as:
-        The winner is: <winnerUid>
-        Winner message: <short message>
-        Loser message: <short message> 
-        """
+      2. **Determining the Winner:**
+      - Based on the criteria above, decide which AI performed better overall.
+      - Explicitly state the winner in the format: "The winner is: <winnerUid>."
+
+      3. **Feedback for Both AIs:**
+      - **Winner's Feedback:** Provide specific strengths that led to their victory.
+      - **Loser's Feedback:** Offer constructive criticism highlighting areas for improvement.
+
+      **Format your response as follows:**
+
+      ```
+      The winner is: <winnerUid>
+      
+      Winner message: - <Strength 1>
+                      - <Strength 2>
+                      - <Strength 3>
+
+      Loser message: - <Area for Improvement 1>
+                     - <Area for Improvement 2>
+                     - <Area for Improvement 3>
+      ```
+
+      **Example:**
+
+      ```
+      The winner is: user1Uid
+      Winner's Feedback:
+      - Demonstrated exceptional problem-solving skills with clear, logical explanations.
+      - Provided comprehensive and relevant answers to all questions.
+      - Maintained a high level of professionalism throughout the interview.
+
+      Loser's Feedback:
+      - Responses lacked depth and were sometimes vague.
+      - Failed to fully address some of the interview questions.
+      - Could improve clarity and coherence in communication.
+      ```
+
+      **Transcripts:**
+
+      **$user1Uid's Transcript:**
+      $user1Transcript
+
+      **$user2Uid's Transcript:**
+      $user2Transcript
+      """
+            .trimIndent()
 
     val request =
         ChatRequest(

--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -560,8 +560,11 @@ The session is now over. According to the initial instructions, you can now brea
         $user2Transcript
 
         Please determine who performed better and explicitly state: "The winner is $user1Uid" or "The winner is $user2Uid".
-        Then, provide a message addressed to the winner, highlighting why they won (max one paragraph).
+        Then, provide a message addressed to the winner, highlighting why they won (max one paragraph). 
         Also, provide a message addressed to the loser, highlighting what they did wrong and where they can improve (max one paragraph).
+        For both messages focus on the quality of the answers, clarity, and overall performance. And address both users as "you". 
+        Don't over compliment the winner because he might have also made mistakes, make sure to stay neutral and professional. 
+        
 
         Format your answer as:
         The winner is: <winnerUid>

--- a/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/chatGPT/ChatViewModel.kt
@@ -569,36 +569,17 @@ The session is now over. According to the initial instructions, you can now brea
       3. **Feedback for Both AIs:**
       - **Winner's Feedback:** Provide specific strengths that led to their victory.
       - **Loser's Feedback:** Offer constructive criticism highlighting areas for improvement.
+       
+      Address both AIs as "you" so that we can directly display the feedback message on their screens.
+      
+      Don't over compliment the winner because he might have also made mistakes, make sure to stay neutral and professional: a strict interviewer. 
 
       **Format your response as follows:**
 
-      ```
       The winner is: <winnerUid>
-      
-      Winner message: - <Strength 1>
-                      - <Strength 2>
-                      - <Strength 3>
-
-      Loser message: - <Area for Improvement 1>
-                     - <Area for Improvement 2>
-                     - <Area for Improvement 3>
-      ```
-
-      **Example:**
-
-      ```
-      The winner is: user1Uid
-      Winner's Feedback:
-      - Demonstrated exceptional problem-solving skills with clear, logical explanations.
-      - Provided comprehensive and relevant answers to all questions.
-      - Maintained a high level of professionalism throughout the interview.
-
-      Loser's Feedback:
-      - Responses lacked depth and were sometimes vague.
-      - Failed to fully address some of the interview questions.
-      - Could improve clarity and coherence in communication.
-      ```
-
+      Winner message: <short message that highlights some strengths that would make him more likely to be hired than the loser, while addressing the winner as you instead of his UID>
+      Loser message: <short message that highlights some of the flaws that prevented him from being hired instead of the winner, while addressing the loser as you instead of his UID>
+                   
       **Transcripts:**
 
       **$user1Uid's Transcript:**
@@ -627,12 +608,14 @@ The session is now over. According to the initial instructions, you can now brea
     // Winner message: Congratulations user1Uid, you showed...
     // Loser message: user2Uid, you lacked clarity...
 
+    // Extract the winner UID from the response
     val winnerRegex = Regex("The winner is:\\s*(\\S+)")
     val winnerMatch =
         winnerRegex.find(content) ?: throw IllegalStateException("No winner found in the response")
 
     val winnerUid = winnerMatch.groupValues[1]
 
+    // Extract the winner and loser messages from the response
     val winnerMessageRegex =
         Regex("Winner message:\\s*(.*?)(?=Loser message:|$)", RegexOption.DOT_MATCHES_ALL)
     val loserMessageRegex = Regex("Loser message:\\s*(.*)", RegexOption.DOT_MATCHES_ALL)

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleRepository.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleRepository.kt
@@ -42,4 +42,10 @@ interface BattleRepository {
       evaluationText: String,
       callback: (Boolean) -> Unit
   )
+
+  fun completeBattle(
+      battleId: String,
+      evaluationResult: EvaluationResult,
+      callback: (Boolean) -> Unit
+  )
 }

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleRepositoryFirestore.kt
@@ -346,4 +346,41 @@ class BattleRepositoryFirestore(private val db: FirebaseFirestore) : BattleRepos
           callback(false)
         }
   }
+
+  /**
+   * Completes a battle by updating the status and storing the evaluation result.
+   *
+   * @param battleId The ID of the battle.
+   * @param evaluationResult The evaluation result.
+   * @param callback A callback function to execute.
+   */
+  override fun completeBattle(
+      battleId: String,
+      evaluationResult: EvaluationResult,
+      callback: (Boolean) -> Unit
+  ) {
+    val evaluationMap =
+        mapOf(
+            "winnerUid" to evaluationResult.winnerUid,
+            "winnerMessage" to
+                mapOf(
+                    "role" to evaluationResult.winnerMessage.role,
+                    "content" to evaluationResult.winnerMessage.content),
+            "loserMessage" to
+                mapOf(
+                    "role" to evaluationResult.loserMessage.role,
+                    "content" to evaluationResult.loserMessage.content))
+
+    val updates =
+        mapOf("status" to BattleStatus.COMPLETED.name, "evaluationResult" to evaluationMap)
+
+    db.collection("battles")
+        .document(battleId)
+        .update(updates)
+        .addOnSuccessListener { callback(true) }
+        .addOnFailureListener { e ->
+          Log.e("BattleRepository", "Error completing battle: $e")
+          callback(false)
+        }
+  }
 }

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
@@ -285,7 +285,7 @@ class BattleViewModel(
 
     getBattleById(battleId) { battle ->
       if (battle == null) {
-        onFailure(IllegalStateException("Battle not found"))
+        onFailure(IllegalStateException("Battle not found for ID: $battleId"))
         return@getBattleById
       }
 

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
@@ -303,7 +303,9 @@ class BattleViewModel(
                   user1Uid = battle.challenger,
                   user2Uid = battle.opponent,
                   user1messages = battle.challengerData,
-                  user2messages = battle.opponentData)
+                  user2messages = battle.opponentData,
+                  user1name = userProfileViewModel.getName(battle.challenger),
+                  user2name = userProfileViewModel.getName(battle.opponent))
 
           battleRepository.completeBattle(battleId, evaluationResult) { success ->
             if (!success) {

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
@@ -193,7 +193,7 @@ class BattleViewModel(
 
             if (otherUserCompleted) {
               // Both users are now completed. Update status to COMPLETED.
-              battleRepository.updateBattleStatus(battleId, BattleStatus.COMPLETED) { statusSuccess
+              battleRepository.updateBattleStatus(battleId, BattleStatus.EVALUATING) { statusSuccess
                 ->
                 if (statusSuccess) {
                   navigationActions.navigateToEvaluationScreen(battleId)

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -2,6 +2,7 @@ package com.github.se.orator.ui.battle
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -22,9 +23,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
+import com.github.se.orator.model.speechBattle.SpeechBattle
 import com.github.se.orator.ui.navigation.NavigationActions
 import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
@@ -84,38 +87,60 @@ fun EvaluationScreen(
                         modifier =
                             Modifier.size(AppDimensions.loadingIndicatorSize)
                                 .testTag("loadingIndicator"))
-                    Text("EVALUATING PERFORMANCE AND DETERMINING THE WINNER")
+                    Text(
+                        "EVALUATING PERFORMANCE AND DETERMINING THE WINNER",
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface)
                   }
                 }
           }
           battle!!.status == BattleStatus.COMPLETED && battle!!.evaluationResult != null -> {
             // Battle is completed, show the results
-            val result = battle!!.evaluationResult
-            val userIsWinner = result!!.winnerUid == userId
-            val message =
-                if (userIsWinner) result.winnerMessage.content else result.loserMessage.content
-            val resultText = if (userIsWinner) "You Won!" else "You Lost."
-
-            Box(
-                modifier = Modifier.fillMaxSize().padding(paddingValues),
-                contentAlignment = Alignment.Center) {
-                  Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(resultText, style = MaterialTheme.typography.titleLarge)
-                    Spacer(modifier = Modifier.size(16.dp))
-                    Text(message)
-                    Spacer(modifier = Modifier.size(24.dp))
-                    Text("You can now return to the main screen.")
-                      //TODO: implement navigation or retry mechanism
-                  }
-                }
+            DisplayResultAndFeedback(battle, userId, paddingValues)
           }
           else -> {
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
                 contentAlignment = Alignment.Center) {
-                  Text("Waiting for evaluation to start...")
+                  Text(
+                      "Waiting for evaluation to start...",
+                      color = MaterialTheme.colorScheme.onSurface,
+                      textAlign = TextAlign.Center,
+                      style = MaterialTheme.typography.bodyLarge)
                 }
           }
         }
       })
+}
+
+@Composable
+fun DisplayResultAndFeedback(battle: SpeechBattle?, userId: String, paddingValues: PaddingValues) {
+  val result = battle!!.evaluationResult
+  val userIsWinner = result!!.winnerUid == userId
+  val message = if (userIsWinner) result.winnerMessage.content else result.loserMessage.content
+  val resultText = if (userIsWinner) "You Won!" else "You Lost."
+
+  Box(
+      modifier = Modifier.fillMaxSize().padding(paddingValues),
+      contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+          Text(
+              resultText,
+              style = MaterialTheme.typography.titleLarge,
+              color = MaterialTheme.colorScheme.onSurface,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(horizontal = 16.dp).testTag("resultText"))
+          Spacer(modifier = Modifier.size(16.dp))
+          Text(
+              message,
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.primary,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(horizontal = 16.dp).testTag("message"))
+          Spacer(modifier = Modifier.size(24.dp))
+          Text("You can now return to the main screen.")
+          // TODO: implement navigation or retry mechanism
+        }
+      }
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -1,13 +1,11 @@
 package com.github.se.orator.ui.battle
 
 import android.util.Log
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
@@ -92,7 +90,7 @@ fun EvaluationScreen(
                 }
           }
           battle!!.status == BattleStatus.EVALUATING -> {
-            // Show loading while waiting for completion
+            // Show loading while waiting for evaluation to complete
             Log.d("EvalScreen", "Evaluating result")
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -118,7 +116,7 @@ fun EvaluationScreen(
               Log.d("EvalScreen", "Battle completed")
               DisplayResultAndFeedback(battle, userId, paddingValues, navigationActions)
             } else {
-              // evaluationResult not yet available, possibly wait and retry
+              // EvaluationResult not yet available
               Log.d("EvalScreen", "Battle is COMPLETED but evaluationResult is null")
               Box(
                   modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -203,11 +201,15 @@ fun DisplayResultAndFeedback(
             // opponent wants to retry aswell and then just go to chat)
           }
 
+          Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
+
           ActionButton(text = "Go to Practice") {
             navigationActions.navigateTo(Screen.SPEAKING_JOB_INTERVIEW)
             // TODO: skip implementing the form and jump straight into interview practice (with the
             // same context)
           }
+
+          Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
           ActionButton(text = "Return to Home") { navigationActions.navigateTo(Screen.HOME) }
         }
@@ -226,15 +228,11 @@ fun ActionButton(text: String, onClick: () -> Unit) {
   Button(
       onClick = onClick,
       modifier =
-          Modifier.fillMaxWidth()
-              .padding(top = AppDimensions.paddingSmall)
-              .border(
-                  width = AppDimensions.borderStrokeWidth,
-                  color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
-                  shape = MaterialTheme.shapes.medium),
+          Modifier.size(
+              height = AppDimensions.buttonHeightLarge, width = AppDimensions.buttonWidthMax),
       colors =
-          ButtonDefaults.buttonColors(
-              containerColor = MaterialTheme.colorScheme.surfaceContainerLow)) {
-        Text(text = text, color = MaterialTheme.colorScheme.primary)
-      }
+          ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+  ) {
+    Text(text = text, color = MaterialTheme.colorScheme.onSurface)
+  }
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -10,12 +10,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -26,8 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.model.speechBattle.SpeechBattle
@@ -35,6 +35,7 @@ import com.github.se.orator.ui.navigation.NavigationActions
 import com.github.se.orator.ui.navigation.Screen
 import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
+import com.github.se.orator.ui.theme.AppTypography
 
 /**
  * The composable that is displayed on the evaluation screen
@@ -69,8 +70,14 @@ fun EvaluationScreen(
 
   Scaffold(
       topBar = {
-        TopAppBar(
-            title = { Text("Battle Evaluation", color = MaterialTheme.colorScheme.onSurface) })
+        CenterAlignedTopAppBar(
+            title = {
+              Text(
+                  "Battle Evaluation",
+                  color = MaterialTheme.colorScheme.onSurface,
+                  fontWeight = FontWeight.Bold,
+                  modifier = Modifier.testTag("battleEvaluation"))
+            })
       },
       content = { paddingValues ->
         when {
@@ -78,7 +85,12 @@ fun EvaluationScreen(
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
                 contentAlignment = Alignment.Center) {
-                  Text("Error: $errorMessage", color = MaterialTheme.colorScheme.error)
+                  Text(
+                      "Error: $errorMessage",
+                      color = MaterialTheme.colorScheme.error,
+                      textAlign = TextAlign.Center,
+                      style = MaterialTheme.typography.bodyLarge,
+                      modifier = Modifier.testTag("errorText"))
                 }
           }
           battle == null -> {
@@ -86,7 +98,12 @@ fun EvaluationScreen(
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
                 contentAlignment = Alignment.Center) {
-                  Text("Loading battle data...")
+                  Text(
+                      "Loading battle data...",
+                      color = MaterialTheme.colorScheme.onSurface,
+                      textAlign = TextAlign.Center,
+                      style = MaterialTheme.typography.bodyLarge,
+                      modifier = Modifier.testTag("loadingText"))
                 }
           }
           battle!!.status == BattleStatus.EVALUATING -> {
@@ -102,11 +119,15 @@ fun EvaluationScreen(
                         modifier =
                             Modifier.size(AppDimensions.loadingIndicatorSize)
                                 .testTag("loadingIndicator"))
+
+                    Spacer(modifier = Modifier.size(AppDimensions.paddingMedium))
+
                     Text(
-                        "EVALUATING PERFORMANCE AND DETERMINING THE WINNER",
+                        "Evaluating performance and determining the winner",
                         textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface)
+                        style = AppTypography.loadingTextStyle,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.testTag("loadingText"))
                   }
                 }
           }
@@ -125,7 +146,8 @@ fun EvaluationScreen(
                         "Processing results...",
                         color = MaterialTheme.colorScheme.onSurface,
                         textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyLarge)
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.testTag("processingResults"))
                   }
             }
           }
@@ -138,7 +160,8 @@ fun EvaluationScreen(
                       "Waiting for evaluation to start...",
                       color = MaterialTheme.colorScheme.onSurface,
                       textAlign = TextAlign.Center,
-                      style = MaterialTheme.typography.bodyLarge)
+                      style = MaterialTheme.typography.bodyLarge,
+                      modifier = Modifier.testTag("waitingForEvaluation"))
                 }
           }
         }
@@ -172,29 +195,30 @@ fun DisplayResultAndFeedback(
       modifier = Modifier.fillMaxSize().padding(paddingValues),
       contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
+          // Display the result
           Text(
               resultText,
-              style = MaterialTheme.typography.titleLarge,
-              color = MaterialTheme.colorScheme.onSurface,
+              style = AppTypography.mediumTitleStyle,
+              color = MaterialTheme.colorScheme.primary,
               textAlign = TextAlign.Center,
               modifier =
                   Modifier.padding(horizontal = AppDimensions.paddingSmall).testTag("resultText"))
-          Spacer(modifier = Modifier.size(16.dp))
+
+          Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
+
+          // Display the feedback
           Text(
               message,
               style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.primary,
+              color = MaterialTheme.colorScheme.onSurface,
               textAlign = TextAlign.Center,
               modifier =
                   Modifier.padding(horizontal = AppDimensions.paddingSmall).testTag("message"))
 
           Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
-          Text("You can now return to the main screen.")
+          // Buttons to retry, go to practice or return to home
 
-          Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
-
-          // Use the helper function to add buttons
           ActionButton(text = "Retry") {
             // Navigate to the battle screen again with the same friendUid
             // TODO: implement retry mechanism (with the same context -> maybe just check if
@@ -233,6 +257,7 @@ fun ActionButton(text: String, onClick: () -> Unit) {
       colors =
           ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
   ) {
-    Text(text = text, color = MaterialTheme.colorScheme.onSurface)
+    Text(
+        text = text, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.testTag(text))
   }
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -232,15 +232,16 @@ fun DisplayResultAndFeedback(
           Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
           ActionButton(text = "Go to Practice") {
+            chatViewModel.resetPracticeContext()
+            chatViewModel.endConversation()
             navigationActions.navigateTo(Screen.SPEAKING_JOB_INTERVIEW)
-            // TODO: skip implementing the form and jump straight into interview practice (with the
-            // same context)
           }
 
           Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
           ActionButton(text = "Return to Home") {
             chatViewModel.resetPracticeContext()
+            chatViewModel.endConversation()
             navigationActions.navigateTo(Screen.HOME)
           }
         }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -1,35 +1,121 @@
 package com.github.se.orator.ui.battle
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.se.orator.model.speechBattle.BattleStatus
+import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.theme.AppColors
+import com.github.se.orator.ui.theme.AppDimensions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun EvaluationScreen(battleId: String, navigationActions: NavigationActions) {
+fun EvaluationScreen(
+    userId: String,
+    battleId: String,
+    navigationActions: NavigationActions,
+    battleViewModel: BattleViewModel
+) {
+  val battle by battleViewModel.getBattleByIdFlow(battleId).collectAsState(initial = null)
+  var errorMessage by remember { mutableStateOf<String?>(null) }
+
+  // If challenger and no evaluationResult yet, start evaluation
+  LaunchedEffect(battle) {
+    battle?.let { b ->
+      if (b.status == BattleStatus.EVALUATING &&
+          b.evaluationResult == null &&
+          b.challenger == userId) {
+        battleViewModel.evaluateBattle(battleId) { e -> errorMessage = e.message }
+      }
+    }
+  }
+
   Scaffold(
       topBar = {
         TopAppBar(
-            title = { Text("Evaluation in Progress", color = MaterialTheme.colorScheme.onSurface) })
+            title = { Text("Battle Evaluation", color = MaterialTheme.colorScheme.onSurface) })
       },
       content = { paddingValues ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(paddingValues),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center) {
-              Text(
-                  "GPT is currently evaluating both answers",
-                  color = MaterialTheme.colorScheme.onSurface)
-            }
+        when {
+          errorMessage != null -> {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center) {
+                  Text("Error: $errorMessage", color = MaterialTheme.colorScheme.error)
+                }
+          }
+          battle == null -> {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center) {
+                  Text("Loading battle data...")
+                }
+          }
+          battle!!.status == BattleStatus.EVALUATING -> {
+            // Show loading while waiting for completion
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center) {
+                  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator(
+                        color = AppColors.loadingIndicatorColor,
+                        strokeWidth = AppDimensions.strokeWidth,
+                        modifier =
+                            Modifier.size(AppDimensions.loadingIndicatorSize)
+                                .testTag("loadingIndicator"))
+                    Text("EVALUATING PERFORMANCE AND DETERMINING THE WINNER")
+                  }
+                }
+          }
+          battle!!.status == BattleStatus.COMPLETED && battle!!.evaluationResult != null -> {
+            // Battle is completed, show the results
+            val result = battle!!.evaluationResult
+            val userIsWinner = result!!.winnerUid == userId
+            val message =
+                if (userIsWinner) result.winnerMessage.content else result.loserMessage.content
+            val resultText = if (userIsWinner) "You Won!" else "You Lost."
+
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center) {
+                  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(resultText, style = MaterialTheme.typography.titleLarge)
+                    Spacer(modifier = Modifier.size(16.dp))
+                    Text(message)
+                    Spacer(modifier = Modifier.size(24.dp))
+                    Text("You can now return to the main screen.")
+                      //TODO: implement navigation or retry mechanism
+                  }
+                }
+          }
+          else -> {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center) {
+                  Text("Waiting for evaluation to start...")
+                }
+          }
+        }
       })
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.github.se.orator.model.chatGPT.ChatViewModel
 import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.model.speechBattle.SpeechBattle
@@ -51,7 +52,8 @@ fun EvaluationScreen(
     userId: String,
     battleId: String,
     navigationActions: NavigationActions,
-    battleViewModel: BattleViewModel
+    battleViewModel: BattleViewModel,
+    chatViewModel: ChatViewModel
 ) {
   val battle by battleViewModel.getBattleByIdFlow(battleId).collectAsState(initial = null)
   var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -135,7 +137,8 @@ fun EvaluationScreen(
             if (battle!!.evaluationResult != null) {
               // Battle is completed, show the results
               Log.d("EvalScreen", "Battle completed")
-              DisplayResultAndFeedback(battle, userId, paddingValues, navigationActions)
+              DisplayResultAndFeedback(
+                  battle, userId, paddingValues, navigationActions, chatViewModel)
             } else {
               // EvaluationResult not yet available
               Log.d("EvalScreen", "Battle is COMPLETED but evaluationResult is null")
@@ -181,7 +184,8 @@ fun DisplayResultAndFeedback(
     battle: SpeechBattle?,
     userId: String,
     paddingValues: PaddingValues,
-    navigationActions: NavigationActions
+    navigationActions: NavigationActions,
+    chatViewModel: ChatViewModel
 ) {
 
   val result = battle!!.evaluationResult
@@ -235,7 +239,10 @@ fun DisplayResultAndFeedback(
 
           Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
-          ActionButton(text = "Return to Home") { navigationActions.navigateTo(Screen.HOME) }
+          ActionButton(text = "Return to Home") {
+            chatViewModel.resetPracticeContext()
+            navigationActions.navigateTo(Screen.HOME)
+          }
         }
       }
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -1,12 +1,17 @@
 package com.github.se.orator.ui.battle
 
+import android.util.Log
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -29,9 +34,18 @@ import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.model.speechBattle.SpeechBattle
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.Screen
 import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
 
+/**
+ * The composable that is displayed on the evaluation screen
+ *
+ * @param userId the user id
+ * @param battleId the battle id
+ * @param navigationActions an instance of navigation actions
+ * @param battleViewModel the battle view model
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EvaluationScreen(
@@ -49,6 +63,7 @@ fun EvaluationScreen(
       if (b.status == BattleStatus.EVALUATING &&
           b.evaluationResult == null &&
           b.challenger == userId) {
+        Log.d("EvalScreen", "Calling eval battle")
         battleViewModel.evaluateBattle(battleId) { e -> errorMessage = e.message }
       }
     }
@@ -69,6 +84,7 @@ fun EvaluationScreen(
                 }
           }
           battle == null -> {
+            Log.d("EvalScreen", "Battle is null")
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
                 contentAlignment = Alignment.Center) {
@@ -77,6 +93,7 @@ fun EvaluationScreen(
           }
           battle!!.status == BattleStatus.EVALUATING -> {
             // Show loading while waiting for completion
+            Log.d("EvalScreen", "Evaluating result")
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
                 contentAlignment = Alignment.Center) {
@@ -95,11 +112,27 @@ fun EvaluationScreen(
                   }
                 }
           }
-          battle!!.status == BattleStatus.COMPLETED && battle!!.evaluationResult != null -> {
-            // Battle is completed, show the results
-            DisplayResultAndFeedback(battle, userId, paddingValues)
+          battle!!.status == BattleStatus.COMPLETED -> {
+            if (battle!!.evaluationResult != null) {
+              // Battle is completed, show the results
+              Log.d("EvalScreen", "Battle completed")
+              DisplayResultAndFeedback(battle, userId, paddingValues, navigationActions)
+            } else {
+              // evaluationResult not yet available, possibly wait and retry
+              Log.d("EvalScreen", "Battle is COMPLETED but evaluationResult is null")
+              Box(
+                  modifier = Modifier.fillMaxSize().padding(paddingValues),
+                  contentAlignment = Alignment.Center) {
+                    Text(
+                        "Processing results...",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyLarge)
+                  }
+            }
           }
           else -> {
+            Log.d("EvalScreen", "Else statement: ${battle!!.status}")
             Box(
                 modifier = Modifier.fillMaxSize().padding(paddingValues),
                 contentAlignment = Alignment.Center) {
@@ -114,12 +147,28 @@ fun EvaluationScreen(
       })
 }
 
+/**
+ * Helper method to display result and feedback depending on the user
+ *
+ * @param battle the battle data
+ * @param userId the user id
+ * @param paddingValues the padding values
+ * @param navigationActions the navigation action instance
+ */
 @Composable
-fun DisplayResultAndFeedback(battle: SpeechBattle?, userId: String, paddingValues: PaddingValues) {
+fun DisplayResultAndFeedback(
+    battle: SpeechBattle?,
+    userId: String,
+    paddingValues: PaddingValues,
+    navigationActions: NavigationActions
+) {
+
   val result = battle!!.evaluationResult
   val userIsWinner = result!!.winnerUid == userId
   val message = if (userIsWinner) result.winnerMessage.content else result.loserMessage.content
   val resultText = if (userIsWinner) "You Won!" else "You Lost."
+
+  Log.d("EvalScreen", "Displaying result $resultText $userId")
 
   Box(
       modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -130,17 +179,62 @@ fun DisplayResultAndFeedback(battle: SpeechBattle?, userId: String, paddingValue
               style = MaterialTheme.typography.titleLarge,
               color = MaterialTheme.colorScheme.onSurface,
               textAlign = TextAlign.Center,
-              modifier = Modifier.padding(horizontal = 16.dp).testTag("resultText"))
+              modifier =
+                  Modifier.padding(horizontal = AppDimensions.paddingSmall).testTag("resultText"))
           Spacer(modifier = Modifier.size(16.dp))
           Text(
               message,
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.primary,
               textAlign = TextAlign.Center,
-              modifier = Modifier.padding(horizontal = 16.dp).testTag("message"))
-          Spacer(modifier = Modifier.size(24.dp))
+              modifier =
+                  Modifier.padding(horizontal = AppDimensions.paddingSmall).testTag("message"))
+
+          Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
+
           Text("You can now return to the main screen.")
-          // TODO: implement navigation or retry mechanism
+
+          Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
+
+          // Use the helper function to add buttons
+          ActionButton(text = "Retry") {
+            // Navigate to the battle screen again with the same friendUid
+            // TODO: implement retry mechanism (with the same context -> maybe just check if
+            // opponent wants to retry aswell and then just go to chat)
+          }
+
+          ActionButton(text = "Go to Practice") {
+            navigationActions.navigateTo(Screen.SPEAKING_JOB_INTERVIEW)
+            // TODO: skip implementing the form and jump straight into interview practice (with the
+            // same context)
+          }
+
+          ActionButton(text = "Return to Home") { navigationActions.navigateTo(Screen.HOME) }
         }
+      }
+}
+
+/**
+ * A helper composable to create a styled action button with consistent styling, reducing code
+ * duplication.
+ *
+ * @param text The button label.
+ * @param onClick The lambda to be invoked when the button is clicked.
+ */
+@Composable
+fun ActionButton(text: String, onClick: () -> Unit) {
+  Button(
+      onClick = onClick,
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(top = AppDimensions.paddingSmall)
+              .border(
+                  width = AppDimensions.borderStrokeWidth,
+                  color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                  shape = MaterialTheme.shapes.medium),
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.surfaceContainerLow)) {
+        Text(text = text, color = MaterialTheme.colorScheme.primary)
       }
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/WaitingForCompletionScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.github.se.orator.model.profile.UserProfileViewModel
+import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.ui.navigation.NavigationActions
 import com.github.se.orator.ui.theme.AppColors
@@ -47,7 +48,13 @@ fun WaitingForCompletionScreen(
           if (friendUid == it.opponent) it.opponentCompleted else it.challengerCompleted
 
       if (otherUserCompleted) {
-        // Navigate directly to the evaluation screen
+        // Update the battle status to EVALUATING
+        battleViewModel.updateBattleStatus(battleId, BattleStatus.EVALUATING) { success ->
+          if (!success) {
+            Log.e("WaitingForCompletionScreen", "Failed to update battle status.")
+          }
+        }
+        // Navigate to the evaluation screen
         navigationActions.navigateToEvaluationScreen(battleId)
       } else {
         Log.d("WaitingForCompletionScreen", "Waiting for the other user to finish.")

--- a/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
@@ -8,6 +8,7 @@ import com.github.se.orator.model.speaking.InterviewContext
 import com.github.se.orator.model.speaking.PublicSpeakingContext
 import com.github.se.orator.model.speaking.SalesPitchContext
 import com.github.se.orator.ui.network.ChatGPTService
+import com.github.se.orator.ui.network.ChatRequest
 import com.github.se.orator.ui.network.ChatResponse
 import com.github.se.orator.ui.network.Choice
 import com.github.se.orator.ui.network.Message
@@ -26,6 +27,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -34,6 +36,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 
 class ChatViewModelTest {
@@ -495,4 +498,92 @@ class ChatViewModelTest {
     // Assert
     assert(chatViewModel.errorMessage.value == "Error")
   }
+
+  @Test
+  fun `evaluateBattleCandidates returns correct EvaluationResult when ChatGPT response is valid`() =
+      runTest {
+        chatViewModel = ChatViewModel(chatGPTService, apiLinkViewModel)
+
+        // Arrange
+        val user1Uid = "user1Uid"
+        val user2Uid = "user2Uid"
+        val user1Name = "User One"
+        val user2Name = "User Two"
+
+        val user1Messages =
+            listOf(
+                Message(role = "assistant", content = "Hi from assistant"),
+                Message(role = "user", content = "Hello from user1"))
+
+        val user2Messages =
+            listOf(
+                Message(role = "assistant", content = "Hi from assistant"),
+                Message(role = "user", content = "Hello from user2"))
+
+        val chatGPTResponseContent =
+            """
+            The winner is: $user1Uid
+            Winner message: Congratulations $user1Name, you demonstrated exceptional problem-solving skills.
+            Loser message: $user2Name, you need to improve your communication clarity.
+        """
+                .trimIndent()
+
+        val assistantMessage = Message(role = "assistant", content = chatGPTResponseContent)
+        val choice = Choice(index = 0, message = assistantMessage, finish_reason = "stop")
+        val chatGPTResponse =
+            ChatResponse(
+                id = "test-id",
+                `object` = "chat.completion",
+                created = 1234567890L,
+                model = "gpt-3.5-turbo",
+                choices = listOf(choice),
+                usage = Usage(prompt_tokens = 0, completion_tokens = 0, total_tokens = 0))
+
+        // Mock chatGPTService.getChatCompletion to return the above response
+        `when`(chatGPTService.getChatCompletion(any())).thenReturn(chatGPTResponse)
+
+        // Act
+        val evaluationResult =
+            chatViewModel.evaluateBattleCandidates(
+                user1Uid = user1Uid,
+                user2Uid = user2Uid,
+                user1messages = user1Messages,
+                user2messages = user2Messages,
+                user1name = user1Name,
+                user2name = user2Name)
+
+        // Advance until idle to ensure coroutines run
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Assert
+        assertNotNull(evaluationResult)
+        assertEquals(user1Uid, evaluationResult.winnerUid)
+        assertEquals(
+            "Congratulations $user1Name, you demonstrated exceptional problem-solving skills.",
+            evaluationResult.winnerMessage.content)
+        assertEquals(
+            "$user2Name, you need to improve your communication clarity.",
+            evaluationResult.loserMessage.content)
+
+        // Verify that chatGPTService.getChatCompletion was called with correct ChatRequest
+        val captor = argumentCaptor<ChatRequest>()
+        verify(chatGPTService).getChatCompletion(captor.capture())
+
+        val capturedRequest = captor.firstValue
+        assertEquals("gpt-3.5-turbo", capturedRequest.model)
+
+        // Check that the system message and user prompt are correctly formed
+        assertTrue(capturedRequest.messages.size == 2)
+        val systemMessage = capturedRequest.messages[0]
+        val userPrompt = capturedRequest.messages[1]
+
+        assertEquals("system", systemMessage.role)
+        assertEquals("You are an unbiased strict recruiter.", systemMessage.content)
+
+        // The userPrompt should contain the prompt defined in evaluateBattleCandidates
+        assertTrue(userPrompt.role == "user")
+        assertTrue(
+            userPrompt.content.contains(
+                "You are simulating a highly strict recruiter deciding between two candidates"))
+      }
 }

--- a/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/chatGPT/ChatViewModelTest.kt
@@ -584,6 +584,6 @@ class ChatViewModelTest {
         assertTrue(userPrompt.role == "user")
         assertTrue(
             userPrompt.content.contains(
-                "You are simulating a highly strict recruiter deciding between two candidates"))
+                "You are an impartial and strict recruiter tasked with evaluating two AI interview candidates"))
       }
 }


### PR DESCRIPTION
This PR introduces the evaluation logic, UI for the **Battle of the Interviewers (BOTI)** feature, and the corresponding tests.

#### Key Features:
- **Evaluation Process:**  
   The evaluation begins as soon as both users finish their interaction and access the evaluation screen. The challenger's side initiates the evaluation, and the results are uploaded to Firebase to be shared with the opponent. ChatGPT analyzes the full message history of both users, simulating a strict recruiter to:
   - Decide the winner.
   - Provide constructive feedback tailored for both the winner and the loser.

- **Evaluation Logic Implementation:**  
   - **`evaluateBattleCandidates`:**  
     - Formats chat transcripts for both users and queries ChatGPT to determine the winner.
     - Extracts the winner's UID and feedback for both participants using regex from ChatGPT's response.  
   - **`completeBattle`:** Updates the battle's status in Firestore to `COMPLETED` and stores the evaluation results, making them accessible to both users.

- **Evaluation Screen Implementation:**  
   The evaluation screen transitions through multiple states dynamically:
   - **Loading Data:** While fetching battle data from Firestore.
   - **Evaluating Performance:** Displays a progress indicator during the evaluation process.  
     <img src="https://github.com/user-attachments/assets/d6e48865-86e4-4340-9c2d-a4dd40c26d2d" alt="eval performance" width="400">
   - **Displaying Results:** Shows the outcome and detailed feedback for each user.
   - **Action Buttons:** Once the result is displayed, the screen provides buttons to:
     - Retry the battle.
     - Navigate to the Home screen.
     - Start an Interview Practice session.  
     <img src="https://github.com/user-attachments/assets/c470ce20-1d40-450e-b0b9-b5a6dc1f5e7f" alt="eval done" width="400">

#### Next Steps for BOTI:
- Adding a **cancellation mechanism** to handle cases where users want to exit the battle.
- Implementing a **retry mechanism** to allow users to replay battles with the same opponent.
- Moving the battle initiation flow to a new dedicated screen, streamlining the user experience.