### PR TITLE
Radio buttons for theme selection

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/endtoend/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/endtoend/EndToEndTest.kt
@@ -12,6 +12,7 @@ import com.github.se.orator.model.profile.UserProfile
 import com.github.se.orator.model.profile.UserProfileRepository
 import com.github.se.orator.model.profile.UserProfileViewModel
 import com.github.se.orator.model.profile.UserStatistics
+import com.github.se.orator.model.theme.AppThemeValue
 import com.github.se.orator.model.theme.AppThemeViewModel
 import com.github.se.orator.ui.friends.AddFriendsScreen
 import com.github.se.orator.ui.friends.LeaderboardScreen
@@ -72,7 +73,7 @@ class EndToEndAppTest {
                 org.mockito.kotlin.any(), org.mockito.kotlin.any()))
         .thenReturn(mockSharedPreferences)
     `when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putBoolean(org.mockito.kotlin.any(), org.mockito.kotlin.any()))
+    `when`(mockEditor.putString(org.mockito.kotlin.any(), org.mockito.kotlin.any()))
         .thenReturn(mockEditor)
 
     // mocking the request for the user who is using the app
@@ -173,21 +174,41 @@ class EndToEndAppTest {
         .performClick() // Simulate click on Settings button
     verify(navigationActions).navigateTo(Screen.SETTINGS)
 
-    // test that each setting button exists and is clickable
-    val settingsTags = listOf("theme")
+    // Open the theme dialog
+    composeTestRule.onNodeWithTag("theme").assertExists()
+    composeTestRule.onNodeWithTag("theme").assertHasClickAction()
+    composeTestRule.onNodeWithTag("theme").performClick()
 
-    settingsTags.forEach { tag ->
-      composeTestRule.onNodeWithTag(tag).assertExists()
-      composeTestRule.onNodeWithTag(tag).assertHasClickAction()
-      composeTestRule.onNodeWithTag(tag).performClick()
+    val correctTexts = listOf("Light", "Dark", "System default")
+    // Check if the theme dialog is displayed
+    composeTestRule.onNodeWithTag("settingsThemeDialog").assertIsDisplayed()
+    // Check that each theme option exists and is clickable, and that the text is correctly
+    // formatted
+    AppThemeValue.entries.zip(correctTexts).forEach { (theme, textValue) ->
+      composeTestRule.onNodeWithTag("settingsThemeDialogRow#$theme").assertIsDisplayed()
+      composeTestRule.onNodeWithTag("settingsThemeDialogRow#$theme").assertHasClickAction()
+      composeTestRule.onNodeWithTag("settingsThemeDialogRow#$theme").performClick()
+
+      composeTestRule
+          .onNodeWithTag("settingsThemeDialogText#$theme", useUnmergedTree = true)
+          .assertTextContains(textValue)
     }
-    // Handle the permission button on its own as clicking it will go to the device settings
+
+    // Select the dark theme
+    composeTestRule.onNodeWithTag("settingsThemeDialogRow#${AppThemeValue.DARK}").performClick()
+    // Close the theme dialog by clicking the confirm button
+    composeTestRule
+        .onNodeWithTag("settingsThemeDialogConfirm", useUnmergedTree = true)
+        .performClick()
+    // Check that the theme value is saved correctly
+    assert(appThemeViewModel.currentTheme.value == AppThemeValue.DARK)
+
+    // Assert that the dialog is closed
+    composeTestRule.onNodeWithTag("settingsThemeDialog").assertDoesNotExist()
+
+    // Don't press the permissions button as clicking it would go to the device settings
     composeTestRule.onNodeWithTag("permissions").assertExists()
     composeTestRule.onNodeWithTag("permissions").assertHasClickAction()
-
-    // testing that the theme switch is triggered
-    verify(mockSharedPreferences).edit()
-    verify(mockEditor).putBoolean(org.mockito.kotlin.any(), org.mockito.kotlin.any())
 
     // go back to profile and test the features there
     composeTestRule.onNodeWithTag("back_button").performClick()

--- a/app/src/main/java/com/github/se/orator/model/theme/AppThemeViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/theme/AppThemeViewModel.kt
@@ -4,6 +4,13 @@ import android.content.Context
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+/** Enum class holding the possible values for the app theme. */
+enum class AppThemeValue {
+  LIGHT,
+  DARK,
+  SYSTEM_DEFAULT
+}
+
 /**
  * ViewModel managing the current theme of the app.
  *
@@ -11,7 +18,14 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 class AppThemeViewModel(private val context: Context) {
 
-  private val IS_DARK_NAME = "isDark"
+  private val THEME_STORAGE_LABEL = "themeValueStorage"
+
+  private val _currentTheme = MutableStateFlow(AppThemeValue.SYSTEM_DEFAULT)
+  /**
+   * StateFlow holding the `AppThemeValue` describing the current theme. If you only need to know if
+   * the device is currently in dark or light theme, use the `isDark` object.
+   */
+  val currentTheme = _currentTheme.asStateFlow()
 
   private val _isDark = MutableStateFlow(false)
   /** StateFlow holding the value `true` if the app is in dark mode, `false` otherwise. */
@@ -23,36 +37,60 @@ class AppThemeViewModel(private val context: Context) {
    * Load the theme from memory. If no value present, the theme of the device is used, and saved as
    * the current theme in memory.
    *
-   * @param deviceThemeIsDarkTheme The theme of the device.
+   * @param deviceDefaultThemeIsDark The theme of the device.
    */
-  fun loadTheme(deviceThemeIsDarkTheme: Boolean) {
+  fun loadTheme(deviceDefaultThemeIsDark: Boolean) {
+    deviceThemeIsDarkTheme = deviceDefaultThemeIsDark
+
     val preference =
         context.getSharedPreferences( // NOSONAR - This is not sensitive information
-            "isDark", Context.MODE_PRIVATE)
-    _isDark.value = preference.getBoolean(IS_DARK_NAME, deviceThemeIsDarkTheme)
-    this.deviceThemeIsDarkTheme = deviceThemeIsDarkTheme
+            THEME_STORAGE_LABEL, Context.MODE_PRIVATE)
+
+    _currentTheme.value =
+        AppThemeValue.valueOf(
+            preference.getString(THEME_STORAGE_LABEL, AppThemeValue.SYSTEM_DEFAULT.toString())!!)
+    chooseTheme()
   }
 
   /**
    * Change the theme and save the value to memory, if it is not the same as previously.
    *
-   * @param isDark `true` if the new theme need to be the dark theme.
+   * @param themeValue The new theme to save.
    */
-  fun saveTheme(isDark: Boolean) {
+  fun saveTheme(themeValue: AppThemeValue) {
     val preference =
         context.getSharedPreferences( // NOSONAR - This is not sensitive information
-            "isDark", Context.MODE_PRIVATE)
-    if (isDark != this.isDark.value) {
-      preference.edit().putBoolean(IS_DARK_NAME, isDark).apply()
-      _isDark.value = isDark
+            THEME_STORAGE_LABEL, Context.MODE_PRIVATE)
+    if (themeValue != _currentTheme.value) {
+      preference.edit().putString(THEME_STORAGE_LABEL, themeValue.toString()).apply()
+      _currentTheme.value = themeValue
+      chooseTheme()
     }
   }
 
   /**
    * Switch the theme of the app, from dark to light or light to dark depending on the current
-   * theme.
+   * theme. If the current theme is the system default, the theme is switched to its opposite.
    */
   fun switchTheme() {
-    saveTheme(!isDark.value)
+    when (_currentTheme.value) {
+      AppThemeValue.LIGHT -> saveTheme(AppThemeValue.DARK)
+      AppThemeValue.DARK -> saveTheme(AppThemeValue.LIGHT)
+      AppThemeValue.SYSTEM_DEFAULT ->
+          saveTheme(if (deviceThemeIsDarkTheme) AppThemeValue.DARK else AppThemeValue.LIGHT)
+    }
+  }
+
+  /**
+   * Logic determining which theme to use, differentiating between the system default and the
+   * user-selected theme. This updates the `isDark` object.
+   */
+  private fun chooseTheme() {
+    _isDark.value =
+        when (_currentTheme.value) {
+          AppThemeValue.LIGHT -> false
+          AppThemeValue.DARK -> true
+          AppThemeValue.SYSTEM_DEFAULT -> deviceThemeIsDarkTheme
+        }
   }
 }

--- a/app/src/main/java/com/github/se/orator/model/theme/AppThemeViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/theme/AppThemeViewModel.kt
@@ -22,15 +22,21 @@ class AppThemeViewModel(private val context: Context) {
 
   private val _currentTheme = MutableStateFlow(AppThemeValue.SYSTEM_DEFAULT)
   /**
-   * StateFlow holding the `AppThemeValue` describing the current theme. If you only need to know if
-   * the device is currently in dark or light theme, use the `isDark` object.
+   * StateFlow holding the `AppThemeValue` describing the current theme. Use the `isDark` object if
+   * you only need to know if the device is currently in dark or light theme, without caring about
+   * if the theme is the system default one or instead chosen by the user.
    */
   val currentTheme = _currentTheme.asStateFlow()
 
   private val _isDark = MutableStateFlow(false)
-  /** StateFlow holding the value `true` if the app is in dark mode, `false` otherwise. */
+  /**
+   * StateFlow holding the value `true` if the app is in dark mode, `false` otherwise. This
+   * attribute takes into account the case where the user selected the system default theme :
+   * `isDark` is updated automatically.
+   */
   val isDark = _isDark.asStateFlow()
 
+  // Saves the theme of the device when `loadTheme` is called.
   private var deviceThemeIsDarkTheme = false
 
   /**

--- a/app/src/main/java/com/github/se/orator/model/theme/AppThemeViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/theme/AppThemeViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.se.orator.model.theme
 
 import android.content.Context
+import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
@@ -52,9 +53,14 @@ class AppThemeViewModel(private val context: Context) {
         context.getSharedPreferences( // NOSONAR - This is not sensitive information
             THEME_STORAGE_LABEL, Context.MODE_PRIVATE)
 
-    _currentTheme.value =
-        AppThemeValue.valueOf(
-            preference.getString(THEME_STORAGE_LABEL, AppThemeValue.SYSTEM_DEFAULT.toString())!!)
+    try {
+      _currentTheme.value =
+          AppThemeValue.valueOf(
+              preference.getString(THEME_STORAGE_LABEL, AppThemeValue.SYSTEM_DEFAULT.toString())!!)
+    } catch (e: IllegalArgumentException) {
+      _currentTheme.value = AppThemeValue.SYSTEM_DEFAULT
+      Log.e("AppThemeViewModel", e.message, e)
+    }
     chooseTheme()
   }
 

--- a/app/src/test/java/com/github/se/orator/model/theme/AppThemeViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/theme/AppThemeViewModelTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
-class AppThemeValueViewModelTest {
+class AppThemeViewModelTest {
 
   @Mock private lateinit var mockContext: Context
   @Mock private lateinit var mockSharedPreferences: SharedPreferences
@@ -24,58 +24,59 @@ class AppThemeValueViewModelTest {
   fun setUp() {
     MockitoAnnotations.openMocks(this)
 
-    `when`(mockContext.getSharedPreferences("isDark", Context.MODE_PRIVATE))
+    `when`(mockContext.getSharedPreferences("themeValueStorage", Context.MODE_PRIVATE))
         .thenReturn(mockSharedPreferences)
     `when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putBoolean(any(), any())).thenReturn(mockEditor)
+    `when`(mockEditor.putString(any(), any())).thenReturn(mockEditor)
 
     appThemeViewModel = AppThemeViewModel(mockContext)
 
     // We simulate a value stored in memory equal to "false" in all cases.
-    `when`(mockSharedPreferences.getBoolean(any(), any())).thenReturn(false)
+    `when`(mockSharedPreferences.getString(any(), any())).thenReturn(AppThemeValue.LIGHT.toString())
 
     appThemeViewModel.loadTheme(false)
   }
 
   @Test
   fun loadThemeCorrectlyRetrievesExistingSavedThemeFromMemory() {
-    verify(mockSharedPreferences).getString(eq("isDark"), eq(AppThemeValue.DARK.toString()))
-    assert(!appThemeViewModel.currentTheme.value)
+    verify(mockSharedPreferences)
+        .getString(eq("themeValueStorage"), eq(AppThemeValue.SYSTEM_DEFAULT.toString()))
+    assert(!appThemeViewModel.isDark.value)
   }
 
   @Test
   fun changingTheThemeToTheSameValueAsCurrentDoesNothing() {
-    assert(!appThemeViewModel.currentTheme.value)
-    appThemeViewModel.saveTheme(false)
+    assert(!appThemeViewModel.isDark.value)
+    appThemeViewModel.saveTheme(AppThemeValue.LIGHT)
 
     // The value stored in memory was already false.
     verify(mockSharedPreferences, never()).edit()
-    assert(!appThemeViewModel.currentTheme.value)
+    assert(!appThemeViewModel.isDark.value)
   }
 
   @Test
   fun changingTheThemeToADifferentValueSavesTheNewValue() {
-    assert(!appThemeViewModel.currentTheme.value)
+    assert(!appThemeViewModel.isDark.value)
 
-    appThemeViewModel.saveTheme(true)
+    appThemeViewModel.saveTheme(AppThemeValue.DARK)
 
     verify(mockSharedPreferences).edit()
-    verify(mockEditor).putBoolean(eq("isDark"), eq(true))
+    verify(mockEditor).putString(eq("themeValueStorage"), eq(AppThemeValue.DARK.toString()))
     verify(mockEditor).apply()
 
-    assert(appThemeViewModel.currentTheme.value)
+    assert(appThemeViewModel.isDark.value)
   }
 
   @Test
   fun switchingTheThemeChangesTheTheme() {
-    assert(!appThemeViewModel.currentTheme.value)
+    assert(!appThemeViewModel.isDark.value)
 
     appThemeViewModel.switchTheme()
 
     verify(mockSharedPreferences).edit()
-    verify(mockEditor).putBoolean(eq("isDark"), eq(true))
+    verify(mockEditor).putString(eq("themeValueStorage"), eq(AppThemeValue.DARK.toString()))
     verify(mockEditor).apply()
 
-    assert(appThemeViewModel.currentTheme.value)
+    assert(appThemeViewModel.isDark.value)
   }
 }

--- a/app/src/test/java/com/github/se/orator/model/theme/AppThemeViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/theme/AppThemeViewModelTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
-class AppThemeViewModelTest {
+class AppThemeValueViewModelTest {
 
   @Mock private lateinit var mockContext: Context
   @Mock private lateinit var mockSharedPreferences: SharedPreferences
@@ -39,23 +39,23 @@ class AppThemeViewModelTest {
 
   @Test
   fun loadThemeCorrectlyRetrievesExistingSavedThemeFromMemory() {
-    verify(mockSharedPreferences).getBoolean(eq("isDark"), eq(false))
-    assert(!appThemeViewModel.isDark.value)
+    verify(mockSharedPreferences).getString(eq("isDark"), eq(AppThemeValue.DARK.toString()))
+    assert(!appThemeViewModel.currentTheme.value)
   }
 
   @Test
   fun changingTheThemeToTheSameValueAsCurrentDoesNothing() {
-    assert(!appThemeViewModel.isDark.value)
+    assert(!appThemeViewModel.currentTheme.value)
     appThemeViewModel.saveTheme(false)
 
     // The value stored in memory was already false.
     verify(mockSharedPreferences, never()).edit()
-    assert(!appThemeViewModel.isDark.value)
+    assert(!appThemeViewModel.currentTheme.value)
   }
 
   @Test
   fun changingTheThemeToADifferentValueSavesTheNewValue() {
-    assert(!appThemeViewModel.isDark.value)
+    assert(!appThemeViewModel.currentTheme.value)
 
     appThemeViewModel.saveTheme(true)
 
@@ -63,12 +63,12 @@ class AppThemeViewModelTest {
     verify(mockEditor).putBoolean(eq("isDark"), eq(true))
     verify(mockEditor).apply()
 
-    assert(appThemeViewModel.isDark.value)
+    assert(appThemeViewModel.currentTheme.value)
   }
 
   @Test
   fun switchingTheThemeChangesTheTheme() {
-    assert(!appThemeViewModel.isDark.value)
+    assert(!appThemeViewModel.currentTheme.value)
 
     appThemeViewModel.switchTheme()
 
@@ -76,6 +76,6 @@ class AppThemeViewModelTest {
     verify(mockEditor).putBoolean(eq("isDark"), eq(true))
     verify(mockEditor).apply()
 
-    assert(appThemeViewModel.isDark.value)
+    assert(appThemeViewModel.currentTheme.value)
   }
 }

--- a/app/src/test/java/com/github/se/orator/model/theme/AppThemeViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/theme/AppThemeViewModelTest.kt
@@ -79,4 +79,15 @@ class AppThemeViewModelTest {
 
     assert(appThemeViewModel.isDark.value)
   }
+
+  @Test
+  fun invalidMemoryValueDefaultsToSystemDefault() {
+    assert(!appThemeViewModel.isDark.value)
+
+    `when`(mockSharedPreferences.getString(any(), any())).thenReturn("invalid value")
+
+    appThemeViewModel.loadTheme(true)
+
+    assert(appThemeViewModel.isDark.value)
+  }
 }


### PR DESCRIPTION
This PR improves the theme selection by the user.

### Changes :
* Added a `currentTheme` state flow in `AppThemeViewModel.kt`. It holds a new enum type `AppThemeValue` which can be either `LIGHT`, `DARK`, or `SYSTEM_DEFAULT`. The logic has been updated for the old `isDark` attribute to accordingly be `true` if the app should be in dark mode (`false` if light mode).
* Introduced a new alert dialog box when clicking on the "Theme" button in the settings screen. There are three radio buttons in this dialog : "Light", "Dark" and "System default". The changes are applied only when the "confirm" button is pressed (dismissing the dialog does not save the changes).
* Added new tests and updated old ones to stay up to date with these changes.

Here is a visual peek at the changes (my device is in dark mode) :

<p align="center"><img src="https://github.com/user-attachments/assets/0c5b15f9-7806-48d4-aea6-7b7f73a52ff9" height="500"></p>

Waiting for your feedback ! Also, don't hesitate if there is missing documentation (especially for public methods) or if you find any bugs !