### PR TITLE
Fix : speaking practice module UI

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
@@ -210,7 +210,7 @@ fun SpeakingPracticeModule(
                           },
                           modifier =
                               Modifier.fillMaxWidth()
-                                  .height(input.height)
+                                  .height(input.height + AppDimensions.paddingSmall)
                                   .border(
                                       width = AppDimensions.borderStrokeWidth,
                                       color = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/SpeakingPracticeModule.kt
@@ -322,8 +322,10 @@ fun FocusAreaDropdown(
             colors =
                 TextFieldDefaults.textFieldColors(
                     containerColor = MaterialTheme.colorScheme.surface,
-                    cursorColor = MaterialTheme.colorScheme.primary,
-                ))
+                    cursorColor = MaterialTheme.colorScheme.primary),
+            textStyle =
+                LocalTextStyle.current.copy(
+                    color = MaterialTheme.colorScheme.onSurface)) // Apply text color
         ExposedDropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },


### PR DESCRIPTION
This PR addresses minor UI inconsistencies in the Speaking Practice module that I discovered when testing the app on a tablet. The following issues were identified and resolved:

- **Text in Boxes:** The text was not fully visible due to insufficient height. Added padding to ensure the text is displayed completely.
- **Dropdown Menu in Dark Mode:** Items were not displayed correctly. Updated the `textStyle` and adjusted the styling to improve visibility in dark mode. 