### PR TITLE
fix: bottom navigation menu padding

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/orator/ui/navigation/BottomNavigationMenu.kt
@@ -41,12 +41,14 @@ fun BottomNavigationMenu(
                   Icon(
                       tab.coloredIcon,
                       contentDescription = null,
-                      tint = MaterialTheme.colorScheme.primary)
+                      tint = MaterialTheme.colorScheme.primary,
+                      modifier = Modifier.padding(AppDimensions.smallPadding))
                 } else {
                   Icon(
                       tab.outlinedIcon,
                       contentDescription = null,
-                      tint = MaterialTheme.colorScheme.onSurface)
+                      tint = MaterialTheme.colorScheme.onSurface,
+                      modifier = Modifier.padding(AppDimensions.smallPadding))
                 }
               },
               label = { Text(tab.textId, color = MaterialTheme.colorScheme.onSurface) },


### PR DESCRIPTION
This PR fixes an issue in the Bottom Navigation Bar that I encountered while using the app on a tablet. The icon and text were overlapping. To fix this, I added padding to ensure proper spacing, so the icon and text are no longer on top of each other. This closes #292 