### PR TITLE
Fix data saving and display in stat screen

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfile.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfile.kt
@@ -75,7 +75,7 @@ data class UserStatistics(
     val improvement: Float = 0.0f,
     val battleStats: List<SpeechBattle> = emptyList(),
     val previousRuns: List<SpeechStats> = emptyList(),
-    val recentData: ArrayDeque<AnalysisData> = ArrayDeque(),
+    val recentData: List<AnalysisData> = emptyList(),
     val talkTimeSecMean: Double = 0.0,
     val talkTimePercMean: Double = 0.0
 )

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestore.kt
@@ -2,10 +2,10 @@ package com.github.se.orator.model.profile
 
 import android.net.Uri
 import android.util.Log
-import com.github.se.orator.model.speaking.AnalysisData
 import com.github.se.orator.utils.formatDate
 import com.github.se.orator.utils.getCurrentDate
 import com.github.se.orator.utils.getDaysDifference
+import com.github.se.orator.utils.mapToAnalysisData
 import com.github.se.orator.utils.mapToSpeechBattle
 import com.github.se.orator.utils.parseDate
 import com.google.android.gms.tasks.Task
@@ -251,19 +251,7 @@ class UserProfileRepositoryFirestore(private val db: FirebaseFirestore) : UserPr
             // Extract 'recentData' list
             val recentDataList =
                 (statisticsMap["recentData"] as? List<Map<String, Any>>) ?: emptyList()
-            val recentData =
-                recentDataList.map { dataMap ->
-                  AnalysisData(
-                      transcription = dataMap["transcription"] as? String ?: "",
-                      fillerWordsCount = (dataMap["fillerWordsCount"] as? Number)?.toInt() ?: -1,
-                      averagePauseDuration =
-                          (dataMap["averagePauseDuration"] as? Number)?.toDouble() ?: -1.0,
-                      sentimentScore = (dataMap["sentimentScore"] as? Number)?.toDouble() ?: 0.0,
-                      talkTimePercentage =
-                          (dataMap["talkTimePercentage"] as? Number)?.toDouble() ?: -1.0,
-                      talkTimeSeconds = (dataMap["talkTimeSeconds"] as? Number)?.toDouble() ?: -1.0,
-                      pace = (dataMap["pace"] as? Number)?.toInt() ?: -1)
-                }
+            val recentData = recentDataList.map { dataMap -> mapToAnalysisData(dataMap) }
             // Extract means
             val talkTimeSecMean = (it["talkTimeSecMean"] as? Number)?.toDouble() ?: 0.0
             val talkTimePercMean = (it["talkTimePercMean"] as? Number)?.toDouble() ?: 0.0

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
@@ -130,6 +130,8 @@ class UserProfileViewModel(internal val repository: UserProfileRepository) : Vie
         onSuccess = { profile ->
           userProfile_.value = profile
           profile?.let {
+            recentData_.value = ArrayDeque(profile.statistics.recentData)
+
             // Fetch Friends Profiles
             fetchFriendsProfiles(it.friends)
 
@@ -540,7 +542,7 @@ class UserProfileViewModel(internal val repository: UserProfileRepository) : Vie
       val updatedQueue = addData(recentData_, value)
 
       // Create a new statistics object with the updated queue
-      val updatedStats = currentStats.copy(recentData = updatedQueue)
+      val updatedStats = currentStats.copy(recentData = updatedQueue.toList())
       // Create a new profile object with the updated queue
       val updatedProfile = currentUserProfile.copy(statistics = updatedStats)
 

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -194,9 +194,12 @@ fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String, yMin: F
               .padding(start = paddingExtraLarge, top = paddingSmall)
               .testTag(testTag)) {
         // Use the provided yMin and yMax instead of computing from data
-        val minY = yMin
-        val maxY = yMax
-        val yRange = maxY - minY
+        val maxY = yValues.maxOrNull() ?: FULL // full being the const value for 1f
+        val minY = ZERO // zero for the value 0f
+        var yRange = maxY - minY
+        if (yRange < 9f) {
+          yRange = 9f
+        }
 
         // If by any chance yRange is 0, fallback to 1f
         val adjustedYRange = if (yRange == ZERO) FULL else yRange

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -47,6 +49,7 @@ import com.github.se.orator.ui.theme.AppDimensions.graphHeight
 import com.github.se.orator.ui.theme.AppDimensions.graphWidth
 import com.github.se.orator.ui.theme.AppDimensions.paddingExtraLarge
 import com.github.se.orator.ui.theme.AppDimensions.paddingSmall
+import com.github.se.orator.ui.theme.AppDimensions.paddingXXLarge
 import com.github.se.orator.ui.theme.AppTypography
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -68,103 +71,105 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
       },
       modifier = Modifier.fillMaxSize(),
       content = { padding ->
-        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-          userProfile?.let { profile ->
-            Text(
-                modifier =
-                    Modifier.padding(start = AppDimensions.paddingXXLarge)
-                        .padding(top = AppDimensions.paddingXXLarge)
-                        .testTag("graphScreenTitle"),
-                text = "Statistics Graph",
-                style = AppTypography.mediumTitleStyle, // Apply custom style for title
-                color = MaterialTheme.colorScheme.primary)
+        Column(
+            modifier =
+                Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState())) {
+              userProfile?.let { profile ->
+                Text(
+                    modifier =
+                        Modifier.padding(start = AppDimensions.paddingXXLarge)
+                            .padding(top = AppDimensions.paddingXXLarge)
+                            .testTag("graphScreenTitle"),
+                    text = "Statistics Graph",
+                    style = AppTypography.mediumTitleStyle, // Apply custom style for title
+                    color = MaterialTheme.colorScheme.primary)
 
-            Text(
-                modifier =
-                    Modifier.padding(start = AppDimensions.paddingXXLarge)
-                        .padding(top = AppDimensions.paddingExtraLarge)
-                        .testTag("talkTimeSecTitle"),
-                text = "Talk Time Seconds:",
-                style = AppTypography.smallTitleStyle, // Apply custom style for title
-                color = MaterialTheme.colorScheme.onSurface)
+                Text(
+                    modifier =
+                        Modifier.padding(start = AppDimensions.paddingXXLarge)
+                            .padding(top = AppDimensions.paddingExtraLarge)
+                            .testTag("talkTimeSecTitle"),
+                    text = "Talk Time Seconds:",
+                    style = AppTypography.smallTitleStyle, // Apply custom style for title
+                    color = MaterialTheme.colorScheme.onSurface)
 
-            Row() {
-              Column(
-                  modifier =
-                      Modifier.padding(
-                          top = paddingExtraLarge,
-                          bottom = paddingExtraLarge,
-                          start = paddingExtraLarge)) {
-                    LineChart(
-                        xValues,
-                        profileViewModel.ensureListSizeTen(
-                            profile.statistics.recentData.toList().map { data ->
-                              data.talkTimeSeconds.toFloat()
-                            }),
-                        "talkTimeSecGraph")
-                  }
+                Row() {
+                  Column(
+                      modifier =
+                          Modifier.padding(
+                              top = paddingExtraLarge,
+                              bottom = paddingExtraLarge,
+                              start = paddingExtraLarge)) {
+                        LineChart(
+                            xValues,
+                            profileViewModel.ensureListSizeTen(
+                                profile.statistics.recentData.toList().map { data ->
+                                  data.talkTimeSeconds.toFloat()
+                                }),
+                            "talkTimeSecGraph")
+                      }
 
-              Column(
-                  modifier =
-                      Modifier.padding(
-                          top = paddingExtraLarge,
-                          bottom = paddingExtraLarge,
-                          start = paddingExtraLarge)) {
-                    Text(
-                        modifier =
-                            Modifier.padding(start = AppDimensions.paddingLarge)
-                                .padding(top = AppDimensions.paddingExtraLarge)
-                                .testTag("talkTimeSecMeanTitle"),
-                        text = "Mean: ${profile.statistics.talkTimeSecMean}",
-                        style = AppTypography.smallTitleStyle, // Apply custom style for title
-                        color = MaterialTheme.colorScheme.onSurface)
-                  }
+                  Column(
+                      modifier =
+                          Modifier.padding(
+                              top = paddingExtraLarge,
+                              bottom = paddingExtraLarge,
+                              start = paddingExtraLarge)) {
+                        Text(
+                            modifier =
+                                Modifier.padding(start = AppDimensions.paddingLarge)
+                                    .padding(top = AppDimensions.paddingExtraLarge)
+                                    .testTag("talkTimeSecMeanTitle"),
+                            text = "Mean: ${profile.statistics.talkTimeSecMean}",
+                            style = AppTypography.smallTitleStyle, // Apply custom style for title
+                            color = MaterialTheme.colorScheme.onSurface)
+                      }
+                }
+
+                Text(
+                    modifier =
+                        Modifier.padding(start = AppDimensions.paddingXXLarge)
+                            .padding(top = AppDimensions.paddingExtraLarge)
+                            .testTag("talkTimePercTitle"),
+                    text = "Talk Time Percentage:",
+                    style = AppTypography.smallTitleStyle, // Apply custom style for title
+                    color = MaterialTheme.colorScheme.onSurface)
+
+                Row() {
+                  Column(
+                      modifier =
+                          Modifier.padding(
+                              top = paddingExtraLarge,
+                              bottom = paddingExtraLarge,
+                              start = paddingExtraLarge)) {
+                        LineChart(
+                            xValues,
+                            profileViewModel.ensureListSizeTen(
+                                profile.statistics.recentData.toList().map { data ->
+                                  data.talkTimePercentage.toFloat()
+                                }),
+                            "talkTimePercGraph")
+                      }
+
+                  Column(
+                      modifier =
+                          Modifier.padding(
+                              top = paddingExtraLarge,
+                              bottom = paddingExtraLarge,
+                              start = paddingExtraLarge)) {
+                        Text(
+                            modifier =
+                                Modifier.padding(start = AppDimensions.paddingLarge)
+                                    .padding(top = AppDimensions.paddingExtraLarge)
+                                    .testTag("talkTimePercMeanTitle"),
+                            text = "Mean: ${profile.statistics.talkTimePercMean}",
+                            style = AppTypography.smallTitleStyle, // Apply custom style for title
+                            color = MaterialTheme.colorScheme.onSurface)
+                      }
+                }
+                TitleAndStatsRow(profile)
+              }
             }
-
-            Text(
-                modifier =
-                    Modifier.padding(start = AppDimensions.paddingXXLarge)
-                        .padding(top = AppDimensions.paddingExtraLarge)
-                        .testTag("talkTimePercTitle"),
-                text = "Talk Time Percentage:",
-                style = AppTypography.smallTitleStyle, // Apply custom style for title
-                color = MaterialTheme.colorScheme.onSurface)
-
-            Row() {
-              Column(
-                  modifier =
-                      Modifier.padding(
-                          top = paddingExtraLarge,
-                          bottom = paddingExtraLarge,
-                          start = paddingExtraLarge)) {
-                    LineChart(
-                        xValues,
-                        profileViewModel.ensureListSizeTen(
-                            profile.statistics.recentData.toList().map { data ->
-                              data.talkTimePercentage.toFloat()
-                            }),
-                        "talkTimePercGraph")
-                  }
-
-              Column(
-                  modifier =
-                      Modifier.padding(
-                          top = paddingExtraLarge,
-                          bottom = paddingExtraLarge,
-                          start = paddingExtraLarge)) {
-                    Text(
-                        modifier =
-                            Modifier.padding(start = AppDimensions.paddingLarge)
-                                .padding(top = AppDimensions.paddingExtraLarge)
-                                .testTag("talkTimePercMeanTitle"),
-                        text = "Mean: ${profile.statistics.talkTimePercMean}",
-                        style = AppTypography.smallTitleStyle, // Apply custom style for title
-                        color = MaterialTheme.colorScheme.onSurface)
-                  }
-            }
-            TitleAndStatsRow(profile)
-          }
-        }
       },
       bottomBar = {
         BottomNavigationMenu(
@@ -304,7 +309,10 @@ fun ModeStatsColumn(titleTestTag: String, mode: String, profile: UserProfile) {
 @Composable
 fun TitleAndStatsRow(profile: UserProfile) {
   Row(
-      modifier = Modifier.fillMaxWidth().padding(horizontal = AppDimensions.paddingMedium),
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(horizontal = AppDimensions.paddingMedium)
+              .padding(bottom = paddingXXLarge),
       horizontalArrangement = Arrangement.SpaceEvenly) {
         ModeStatsColumn("InterviewTitle", "Interview", profile)
         ModeStatsColumn("SpeechTitle", "Speech", profile)

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -106,7 +106,9 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                                 profile.statistics.recentData.toList().map { data ->
                                   data.talkTimeSeconds.toFloat()
                                 }),
-                            "talkTimeSecGraph")
+                            "talkTimeSecGraph",
+                            yMin = 0f,
+                            yMax = 60f)
                       }
 
                   Column(
@@ -148,7 +150,9 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                                 profile.statistics.recentData.toList().map { data ->
                                   data.talkTimePercentage.toFloat()
                                 }),
-                            "talkTimePercGraph")
+                            "talkTimePercGraph",
+                            yMin = 0f,
+                            yMax = 100f)
                       }
 
                   Column(
@@ -180,7 +184,7 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
 }
 
 @Composable
-fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String) {
+fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String, yMin: Float, yMax: Float) {
   require(xValues.size == yValues.size) { "X and Y values must have the same size." }
 
   Canvas(
@@ -189,12 +193,12 @@ fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String) {
               .height(graphHeight)
               .padding(start = paddingExtraLarge, top = paddingSmall)
               .testTag(testTag)) {
-        val maxX = xValues.maxOrNull()?.toFloat() ?: FULL // full being the const value for 1f
-        val maxY = yValues.maxOrNull() ?: FULL
-        val minY = yValues.minOrNull() ?: ZERO // zero for the value 0f
+        // Use the provided yMin and yMax instead of computing from data
+        val minY = yMin
+        val maxY = yMax
         val yRange = maxY - minY
 
-        // Avoid division by zero: Assign a minimal range if all yValues are the same
+        // If by any chance yRange is 0, fallback to 1f
         val adjustedYRange = if (yRange == ZERO) FULL else yRange
         val xStep = size.width / (xValues.size - 1)
         val yScale = size.height / adjustedYRange
@@ -256,9 +260,7 @@ fun LineChart(xValues: List<Int>, yValues: List<Float>, testTag: String) {
         for (i in xValues.indices) {
           val x = i * xStep
           val y = size.height - (yValues[i] - minY) * yScale
-          drawCircle(
-              color = graphDots, center = Offset(x, y), radius = POINTS_RADIUS // Smaller point size
-              )
+          drawCircle(color = graphDots, center = Offset(x, y), radius = POINTS_RADIUS)
         }
       }
 }

--- a/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/profile/StatScreen.kt
@@ -103,12 +103,12 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                         LineChart(
                             xValues,
                             profileViewModel.ensureListSizeTen(
-                                profile.statistics.recentData.toList().map { data ->
+                                profile.statistics.recentData.map { data ->
                                   data.talkTimeSeconds.toFloat()
                                 }),
                             "talkTimeSecGraph",
                             yMin = 0f,
-                            yMax = 60f)
+                            yMax = 10f)
                       }
 
                   Column(
@@ -147,7 +147,7 @@ fun GraphStats(navigationActions: NavigationActions, profileViewModel: UserProfi
                         LineChart(
                             xValues,
                             profileViewModel.ensureListSizeTen(
-                                profile.statistics.recentData.toList().map { data ->
+                                profile.statistics.recentData.map { data ->
                                   data.talkTimePercentage.toFloat()
                                 }),
                             "talkTimePercGraph",

--- a/app/src/main/java/com/github/se/orator/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/se/orator/ui/theme/Theme.kt
@@ -266,7 +266,7 @@ object AppDimensions {
   const val FULL: Float = 1f // Assuming this is a constant and doesn't need scaling
   const val ZERO: Float = 0f
   const val X_VALUE_FOR_OFFSET: Float = -20f
-  const val DRAW_TEXT_TICK_LABEL_X: Float = -50f
+  const val DRAW_TEXT_TICK_LABEL_X: Float = -70f
   const val DRAW_TEXT_TICK_LABEL_OFFSET_VALUE_FOR_Y: Float = 10f
   const val TICK_LABEL_TEXT_SIZE: Float = 20f
   const val AXIS_STROKE_WIDTH: Float = 10f

--- a/app/src/main/java/com/github/se/orator/utils/FirestoreHelperMethods.kt
+++ b/app/src/main/java/com/github/se/orator/utils/FirestoreHelperMethods.kt
@@ -1,6 +1,7 @@
 package com.github.se.orator.utils
 
 import android.util.Log
+import com.github.se.orator.model.speaking.AnalysisData
 import com.github.se.orator.model.speaking.InterviewContext
 import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.EvaluationResult
@@ -56,6 +57,23 @@ fun mapToSpeechBattle(data: Map<String, Any>): SpeechBattle? {
     Log.e("UserProfileRepository", "Error converting map to SpeechBattle", e)
     null
   }
+}
+
+/**
+ * Converts a Firestore map to an AnalysisData object.
+ *
+ * @param dataMap The map containing AnalysisData data.
+ * @return An AnalysisData object.
+ */
+fun mapToAnalysisData(dataMap: Map<String, Any>): AnalysisData {
+  return AnalysisData(
+      transcription = dataMap["transcription"] as? String ?: "",
+      fillerWordsCount = (dataMap["fillerWordsCount"] as? Number)?.toInt() ?: -1,
+      averagePauseDuration = (dataMap["averagePauseDuration"] as? Number)?.toDouble() ?: -1.0,
+      sentimentScore = (dataMap["sentimentScore"] as? Number)?.toDouble() ?: 0.0,
+      talkTimePercentage = (dataMap["talkTimePercentage"] as? Number)?.toDouble() ?: -1.0,
+      talkTimeSeconds = (dataMap["talkTimeSeconds"] as? Number)?.toDouble() ?: -1.0,
+      pace = (dataMap["pace"] as? Number)?.toInt() ?: -1)
 }
 
 /**

--- a/app/src/test/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestoreTest.kt
@@ -291,11 +291,32 @@ class UserProfileRepositoryFirestoreTest {
                             mapOf(
                                 "role" to "assistant",
                                 "content" to "You lost the battle. Better luck next time."))))
+
+    // Prepare the recentData list
+    val recentDataList =
+        listOf(
+            mapOf(
+                "transcription" to "Hello world",
+                "fillerWordsCount" to 3L,
+                "averagePauseDuration" to 1.5,
+                "sentimentScore" to 0.75,
+                "talkTimePercentage" to 50.0,
+                "talkTimeSeconds" to 30.0,
+                "pace" to 120L),
+            mapOf(
+                "transcription" to "Another speech",
+                "fillerWordsCount" to 1L,
+                "averagePauseDuration" to 2.0,
+                "sentimentScore" to -0.25,
+                "talkTimePercentage" to 70.0,
+                "talkTimeSeconds" to 45.0,
+                "pace" to 150L))
     val statisticsMap =
         mapOf(
             "sessionsGiven" to sessionsGivenMap,
             "successfulSessions" to successfulSessionsMap,
             "improvement" to 4.5f,
+            "recentData" to recentDataList,
             "battleStats" to battleStatsList)
 
     // Mock the statistics field in the DocumentSnapshot
@@ -330,6 +351,25 @@ class UserProfileRepositoryFirestoreTest {
           assert(statistics?.successfulSessions?.get("SPEECH") == 7)
           assert(statistics?.successfulSessions?.get("INTERVIEW") == 2)
           assert(statistics?.successfulSessions?.get("NEGOTIATION") == 1)
+
+          // Assertions for recentData
+          val recentData = statistics?.recentData
+          assert(recentData?.size == 2)
+          assert(recentData?.get(0)?.transcription == "Hello world")
+          assert(recentData?.get(0)?.fillerWordsCount == 3)
+          assert(recentData?.get(0)?.averagePauseDuration == 1.5)
+          assert(recentData?.get(0)?.sentimentScore == 0.75)
+          assert(recentData?.get(0)?.talkTimePercentage == 50.0)
+          assert(recentData?.get(0)?.talkTimeSeconds == 30.0)
+          assert(recentData?.get(0)?.pace == 120)
+
+          assert(recentData?.get(1)?.transcription == "Another speech")
+          assert(recentData?.get(1)?.fillerWordsCount == 1)
+          assert(recentData?.get(1)?.averagePauseDuration == 2.0)
+          assert(recentData?.get(1)?.sentimentScore == -0.25)
+          assert(recentData?.get(1)?.talkTimePercentage == 70.0)
+          assert(recentData?.get(1)?.talkTimeSeconds == 45.0)
+          assert(recentData?.get(1)?.pace == 150)
 
           assert(statistics?.improvement == 4.5f)
 

--- a/app/src/test/java/com/github/se/orator/model/profile/UserProfileViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/profile/UserProfileViewModelTest.kt
@@ -352,13 +352,6 @@ class UserProfileViewModelTest {
 
   @Test
   fun `addNewestData should maintain a maximum size of 10 in recentData`() = runTest {
-    // Arrange
-    doAnswer { invocation ->
-          val onSuccess = invocation.getArgument<() -> Unit>(1)
-          onSuccess()
-        }
-        .`when`(repository)
-        .updateUserProfile(any(), any(), any())
 
     // Prepopulate recentData with 10 items
     for (i in 1..10) {
@@ -438,13 +431,6 @@ class UserProfileViewModelTest {
 
   @Test
   fun `updateMetricMean should calculate means and update user profile`() = runTest {
-    // Arrange
-    doAnswer { invocation ->
-          val onSuccess = invocation.getArgument<() -> Unit>(1)
-          onSuccess()
-        }
-        .`when`(repository)
-        .updateUserProfile(any(), any(), any())
 
     // Add several AnalysisData items
     val analysisDataList =


### PR DESCRIPTION
This Pull Request refactors how recent speech analysis data is stored and displayed, going from an ArrayDeque to a List for UserStatistics.recentData to make serialization from firestore easier. Alongside this data model change, the problem in the display of the metrics extracted from the data is now fixed and the UI in StatScreen is updated to be scrollable, ensuring that graphs and statistics are more accessible and visually clear.

Data Model Improvements:

- Replaced recentData in UserStatistics from an ArrayDeque<AnalysisData> to a List<AnalysisData> and made the conversion '_arrayDeque_'.toList() in the UserProfileViewModel.
- Updated UserProfileRepositoryFirestore to correctly extract and map recentData as a list from Firestore (serialization).
- Update getUserProfile to save correctly the data 

UI Enhancements:

- Made the StatScreen vertically scrollable (on some screens some composables were hidden).
- Adjusted the values displayed on the y-axis to represent better the intervals of the real values (might change the interval for the talk time seconds y-axis)
- Updated get metric mean to only take two numbers after the decimal for better and cleaner display of the means on the stat screen

Preview:
<img width="256" alt="UpdStatScr" src="https://github.com/user-attachments/assets/183709fc-9d88-43c6-a971-098484a48fe2" />

Related issue:
#273
#297 

In this PR , the main bugs of saving and displaying recentData on the statScreen are finally fixed.

