### PR TITLE
feature: BOTI cancelling

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/battle/BattleChatScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/battle/BattleChatScreenTest.kt
@@ -149,7 +149,7 @@ class BattleChatScreenTest {
   }
 
   @Test
-  fun backButtonNavigatesBack() = runTest {
+  fun backButtonIsNotDisplayed() = runTest {
     composeTestRule.setContent {
       BattleChatScreen(
           battleId = "testBattle",
@@ -160,9 +160,7 @@ class BattleChatScreenTest {
           userProfileViewModel = userProfileViewModel)
     }
 
-    composeTestRule.onNodeWithTag("back_button").performClick()
-
-    verify(mockNavigationActions).goBack()
+    composeTestRule.onNodeWithTag("back_button").assertDoesNotExist()
   }
 
   @Test

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
@@ -277,4 +277,14 @@ class BattleViewModel(
       }
     }
   }
+
+  fun cancelBattle(battleId: String) {
+    battleRepository.updateBattleStatus(battleId, BattleStatus.CANCELLED) { success ->
+      if (success) {
+        Log.d("BattleViewModel", "Battle cancelled successfully.")
+      } else {
+        Log.e("BattleViewModel", "Failed to cancel battle.")
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleChatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleChatScreen.kt
@@ -56,5 +56,6 @@ fun BattleChatScreen(
       onChatButtonClick = {
         // Handle finishing the battle session
         battleViewModel.markUserBattleCompleted(battleId, userId, chatMessages)
-      })
+      },
+      showBackButton = false)
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -68,6 +68,8 @@ fun BattleRequestSentScreen(
       if (event == Lifecycle.Event.ON_STOP) {
         if (battleStatus == BattleStatus.PENDING) {
           battleViewModel.cancelBattle(battleId)
+          Toast.makeText(context, "Battle cancelled", Toast.LENGTH_LONG).show()
+          navigationActions.navigateTo(TopLevelDestinations.HOME)
           Log.d("BattleRequestSentScreen", "Battle canceled due to app backgrounded.")
         }
       }

--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
@@ -27,6 +26,8 @@ import com.github.se.orator.ui.navigation.NavigationActions
 import com.github.se.orator.ui.navigation.TopLevelDestinations
 import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
+import com.github.se.orator.ui.theme.cancelButtonColor
+import com.github.se.orator.ui.theme.cancelButtonTextColor
 
 /**
  * Composable function that displays a message indicating that the battle request has been sent, and
@@ -138,8 +139,8 @@ fun BattleRequestSentScreen(
                     navigationActions.navigateTo(TopLevelDestinations.HOME)
                     Toast.makeText(context, "Battle has been cancelled!", Toast.LENGTH_SHORT).show()
                   },
-                  textColor = Color.White,
-                  buttonColor = Color.Red)
+                  textColor = cancelButtonTextColor,
+                  buttonColor = cancelButtonColor)
             }
       })
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -129,25 +129,15 @@ fun BattleRequestSentScreen(
               Spacer(modifier = Modifier.height(AppDimensions.paddingLarge))
 
               // Cancel Button
-              Button(
+              ActionButton(
+                  "Cancel Battle",
                   onClick = {
                     battleViewModel.cancelBattle(battleId)
                     navigationActions.navigateTo(TopLevelDestinations.HOME)
                     Toast.makeText(context, "Battle has been cancelled!", Toast.LENGTH_SHORT).show()
                   },
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .height(AppDimensions.buttonHeightLarge)
-                          .testTag("cancelButton"),
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = MaterialTheme.colorScheme.error,
-                          contentColor = MaterialTheme.colorScheme.onError)) {
-                    Text(
-                        text = "Cancel battle",
-                        color = Color.White,
-                        modifier = Modifier.testTag("cancelBattleButtonText"))
-                  }
+                  textColor = Color.White,
+                  buttonColor = Color.Red)
             }
       })
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -1,22 +1,30 @@
 package com.github.se.orator.ui.battle
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBackIosNew
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.se.orator.model.profile.UserProfileViewModel
 import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.TopLevelDestinations
 import com.github.se.orator.ui.theme.AppColors
 import com.github.se.orator.ui.theme.AppDimensions
 
@@ -36,6 +44,8 @@ fun BattleRequestSentScreen(
     navigationActions: NavigationActions,
     battleViewModel: BattleViewModel
 ) {
+  val context = LocalContext.current
+
   // Get the friend's name
   val friendName = userProfileViewModel.getName(friendUid)
 
@@ -51,18 +61,38 @@ fun BattleRequestSentScreen(
     }
   }
 
+  // Handle cancellation when the user exits the app via ProcessLifecycleOwner
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val observer = LifecycleEventObserver { _, event ->
+      if (event == Lifecycle.Event.ON_STOP) {
+        if (battleStatus == BattleStatus.PENDING) {
+          battleViewModel.cancelBattle(battleId)
+          Log.d("BattleRequestSentScreen", "Battle canceled due to app backgrounded.")
+        }
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
+
   Scaffold(
       topBar = {
         TopAppBar(
             title = { Text("Battle Request Sent") },
             navigationIcon = {
-              IconButton(onClick = { navigationActions.goBack() }) {
-                Icon(
-                    Icons.Outlined.ArrowBackIosNew,
-                    contentDescription = "Back",
-                    modifier = Modifier.size(AppDimensions.iconSizeMedium).testTag("backButton"),
-                    tint = MaterialTheme.colorScheme.onSurface)
-              }
+              IconButton(
+                  onClick = {
+                    navigationActions.goBack()
+                    battleViewModel.cancelBattle(battleId)
+                  }) {
+                    Icon(
+                        Icons.Outlined.ArrowBackIosNew,
+                        contentDescription = "Back",
+                        modifier =
+                            Modifier.size(AppDimensions.iconSizeMedium).testTag("backButton"),
+                        tint = MaterialTheme.colorScheme.onSurface)
+                  }
             },
             modifier = Modifier.testTag("topAppBar"))
       },
@@ -75,6 +105,8 @@ fun BattleRequestSentScreen(
                     .wrapContentSize(Alignment.Center)
                     .testTag("battleRequestSentScreen"),
             horizontalAlignment = Alignment.CenterHorizontally) {
+
+              // Text indicating that the battle request has been sent
               Text(
                   text =
                       "Interview Battle request has been successfully sent to $friendName.\nWaiting for $friendName to accept the battle.",
@@ -85,11 +117,37 @@ fun BattleRequestSentScreen(
                       Modifier.padding(bottom = AppDimensions.paddingMedium)
                           .testTag("battleRequestSentText"))
 
+              Spacer(modifier = Modifier.height(AppDimensions.paddingLarge))
+
+              // Loading Indicator
               CircularProgressIndicator(
                   color = AppColors.loadingIndicatorColor,
                   strokeWidth = AppDimensions.strokeWidth,
                   modifier =
                       Modifier.size(AppDimensions.loadingIndicatorSize).testTag("loadingIndicator"))
+
+              Spacer(modifier = Modifier.height(AppDimensions.paddingLarge))
+
+              // Cancel Button
+              Button(
+                  onClick = {
+                    battleViewModel.cancelBattle(battleId)
+                    navigationActions.navigateTo(TopLevelDestinations.HOME)
+                    Toast.makeText(context, "Battle has been cancelled!", Toast.LENGTH_SHORT).show()
+                  },
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .height(AppDimensions.buttonHeightLarge)
+                          .testTag("cancelButton"),
+                  colors =
+                      ButtonDefaults.buttonColors(
+                          containerColor = MaterialTheme.colorScheme.error,
+                          contentColor = MaterialTheme.colorScheme.onError)) {
+                    Text(
+                        text = "Cancel battle",
+                        color = Color.White,
+                        modifier = Modifier.testTag("cancelBattleButtonText"))
+                  }
             }
       })
 }

--- a/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/EvaluationScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -223,27 +224,33 @@ fun DisplayResultAndFeedback(
 
           // Buttons to retry, go to practice or return to home
 
-          ActionButton(text = "Retry") {
-            // Navigate to the battle screen again with the same friendUid
-            // TODO: implement retry mechanism (with the same context -> maybe just check if
-            // opponent wants to retry aswell and then just go to chat)
-          }
+          ActionButton(
+              text = "Retry",
+              onClick = {
+                // Navigate to the battle screen again with the same friendUid
+                // TODO: implement retry mechanism (with the same context -> maybe just check if
+                // opponent wants to retry aswell and then just go to chat)
+              })
 
           Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
-          ActionButton(text = "Go to Practice") {
-            chatViewModel.resetPracticeContext()
-            chatViewModel.endConversation()
-            navigationActions.navigateTo(Screen.SPEAKING_JOB_INTERVIEW)
-          }
+          ActionButton(
+              text = "Go to Practice",
+              {
+                chatViewModel.resetPracticeContext()
+                chatViewModel.endConversation()
+                navigationActions.navigateTo(Screen.SPEAKING_JOB_INTERVIEW)
+              })
 
           Spacer(modifier = Modifier.size(AppDimensions.paddingSmall))
 
-          ActionButton(text = "Return to Home") {
-            chatViewModel.resetPracticeContext()
-            chatViewModel.endConversation()
-            navigationActions.navigateTo(Screen.HOME)
-          }
+          ActionButton(
+              text = "Return to Home",
+              onClick = {
+                chatViewModel.resetPracticeContext()
+                chatViewModel.endConversation()
+                navigationActions.navigateTo(Screen.HOME)
+              })
         }
       }
 }
@@ -256,16 +263,20 @@ fun DisplayResultAndFeedback(
  * @param onClick The lambda to be invoked when the button is clicked.
  */
 @Composable
-fun ActionButton(text: String, onClick: () -> Unit) {
+fun ActionButton(
+    text: String,
+    onClick: () -> Unit,
+    buttonColor: Color = MaterialTheme.colorScheme.surfaceContainer,
+    textColor: Color = MaterialTheme.colorScheme.onSurface
+) {
   Button(
       onClick = onClick,
       modifier =
           Modifier.size(
               height = AppDimensions.buttonHeightLarge, width = AppDimensions.buttonWidthMax),
       colors =
-          ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+          ButtonDefaults.buttonColors(containerColor = buttonColor, contentColor = buttonColor),
   ) {
-    Text(
-        text = text, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.testTag(text))
+    Text(text = text, color = textColor, modifier = Modifier.testTag(text))
   }
 }

--- a/app/src/main/java/com/github/se/orator/ui/overview/ChatScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/ChatScreen.kt
@@ -63,7 +63,8 @@ fun ChatScreen(
     navigationActions: NavigationActions,
     chatViewModel: ChatViewModel,
     chatButtonType: ChatButtonType = ChatButtonType.FEEDBACK_BUTTON,
-    onChatButtonClick: () -> Unit = { navigationActions.navigateTo(Screen.FEEDBACK) }
+    onChatButtonClick: () -> Unit = { navigationActions.navigateTo(Screen.FEEDBACK) },
+    showBackButton: Boolean = true
 ) {
   // Collect the list of chat messages from the view model as a state.
   val chatMessages by chatViewModel.chatMessages.collectAsState()
@@ -94,19 +95,23 @@ fun ChatScreen(
                   modifier = Modifier.testTag("chat_screen_title"))
             },
             navigationIcon = {
-              IconButton(
-                  onClick = {
-                    navigationActions.goBack()
-                    chatViewModel.toggleTextToSpeech(false)
-                    chatViewModel.resetPracticeContext()
-                    chatViewModel.endConversation()
-                  },
-                  modifier = Modifier.testTag("back_button")) {
-                    Icon(
-                        imageVector = Icons.Outlined.ArrowBackIosNew,
-                        contentDescription = "Back",
-                        modifier = Modifier.size(AppDimensions.iconSizeSmall),
-                        tint = MaterialTheme.colorScheme.onSurface) // Use theme color for icon
+              if (showBackButton) {
+                IconButton(
+                    onClick = {
+                      navigationActions.goBack()
+                      chatViewModel.toggleTextToSpeech(false)
+                      chatViewModel.resetPracticeContext()
+                      chatViewModel.endConversation()
+                    },
+                    modifier = Modifier.testTag("back_button")) {
+                      Icon(
+                          imageVector = Icons.Outlined.ArrowBackIosNew,
+                          contentDescription = "Back",
+                          modifier = Modifier.size(AppDimensions.iconSizeSmall),
+                          tint = MaterialTheme.colorScheme.onSurface) // Use theme color for icon
+                }
+              } else {
+                null
               }
             },
             colors =

--- a/app/src/main/java/com/github/se/orator/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/se/orator/ui/theme/Color.kt
@@ -124,3 +124,6 @@ val surfaceContainerLowDark = Color(0xFF1B1B21)
 val surfaceContainerDark = Color(0xFF1F1F25)
 val surfaceContainerHighDark = Color(0xFF292A2F)
 val surfaceContainerHighestDark = Color(0xFF34343A)
+
+val cancelButtonColor = Color.Red
+val cancelButtonTextColor = Color.White


### PR DESCRIPTION
This PR introduces a cancelling mechanism for the BOTI battle flow. Users now have the option to cancel their request if the opponent hasn't accepted it yet. Additionally:  
- Navigating away from the "Battle Request Sent" screen will automatically cancel the request.  
- Navigation between certain screens has been restricted to ensure both users remain at the same stage of the battle.  

<img src="https://github.com/user-attachments/assets/676d1b88-93d4-4e57-8033-3f4c758718f5" alt="cancel" width="300" />

#### Changes:
- **`BattleViewModel.kt`**:  
  - Added a `cancelBattle()` function to update the battle status to "Cancelled."  

- **`BattleRequestSentScreen.kt`**:  
  - Added a **Cancel button** to allow users to cancel the battle request.  
  - Ensured that any exit (e.g., navigation) from this screen cancels the request if it hasn’t been accepted.  

- **`BattleChatScreen.kt`**:  
  - Removed the back button to prevent exiting from the chat.  

- **`EvaluationScreen.kt`**:  
  - Refactored the action button to allow customization of button text and background colors.  

- **`ChatScreen.kt`**:  
  - Made the display of the back button optional to enable its removal in the "Battle Chat" screen.  

- **`BattleChatScreenTest.kt`**:  
  - Updated tests to validate that the back button is no longer displayed.  


This PR closes #294