### PR TITLE
feature: BOTI popup screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/friends/FriendsUITests.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/friends/FriendsUITests.kt
@@ -819,7 +819,7 @@ class FriendsUITests {
    */
   @Test
   fun testAcceptPendingBattle() {
-    // Create a mock pending battle
+    // Arrange
     val mockBattles =
         listOf(
             SpeechBattle(
@@ -829,12 +829,12 @@ class FriendsUITests {
                 status = BattleStatus.PENDING,
                 context =
                     InterviewContext(
-                        "testPosition",
-                        "testCompany",
-                        "testType",
-                        "testExperience",
-                        "testDescription",
-                        "testFocusArea")))
+                        interviewType = "Mock Interview",
+                        targetPosition = "Software Engineer",
+                        companyName = "TechCorp",
+                        jobDescription = "Solve coding problems under pressure.",
+                        experienceLevel = "Entry Level",
+                        focusArea = "Problem Solving")))
 
     // Mock getPendingBattlesForUser to return the mockBattles
     doAnswer { invocation ->
@@ -852,7 +852,17 @@ class FriendsUITests {
       null
     }
 
-    // Now render the screen
+    // Mock updateBattleStatus correctly
+    `when`(
+            mockBattleRepository.updateBattleStatus(
+                eq("battle1"), eq(BattleStatus.IN_PROGRESS), any<(Boolean) -> Unit>()))
+        .thenAnswer { invocation ->
+          val callback = invocation.getArgument<(Boolean) -> Unit>(2)
+          callback.invoke(true) // Simulate a successful update
+          null
+        }
+
+    // Act: Render the screen
     composeTestRule.setContent {
       ViewFriendsScreen(
           navigationActions = mockNavigationActions,
@@ -863,13 +873,27 @@ class FriendsUITests {
     // Wait for the UI to render
     composeTestRule.waitForIdle()
 
-    // Verify that the pending battle icon is displayed
+    // Perform UI interactions
+    // Click on the pending battle icon to open the dialog
     composeTestRule
         .onNodeWithTag("pendingBattleIcon#1", useUnmergedTree = true)
         .assertIsDisplayed()
         .performClick()
 
-    // Verify that updateBattleStatus was called to change the status to IN_PROGRESS
+    // Verify that the dialog is displayed
+    composeTestRule.onNodeWithTag("battlePopupTitle").assertExists().assertIsDisplayed()
+
+    // Click on the "Accept" button within the dialog
+    composeTestRule
+        .onNodeWithTag("battlePopupAcceptButton")
+        .assertExists()
+        .assertIsEnabled()
+        .performClick()
+
+    // Wait for the UI to process the state change
+    composeTestRule.waitForIdle()
+
+    // Verify that updateBattleStatus was called correctly
     verify(mockBattleRepository)
         .updateBattleStatus(eq("battle1"), eq(BattleStatus.IN_PROGRESS), any())
   }
@@ -896,5 +920,82 @@ class FriendsUITests {
 
     // Verify that we navigate to the send battle screen with the correct UID
     verify(mockNavigationActions).navigateToSendBattleScreen(eq("2"))
+  }
+
+  @Test
+  fun testDeclinePendingBattle() {
+    // Arrange
+    val mockBattle =
+        SpeechBattle(
+            battleId = "battle2",
+            challenger = "2",
+            opponent = "testUser",
+            status = BattleStatus.PENDING,
+            context =
+                InterviewContext(
+                    interviewType = "Mock Interview",
+                    targetPosition = "Software Engineer",
+                    companyName = "TechCorp",
+                    jobDescription = "Solve coding problems under pressure.",
+                    experienceLevel = "Entry Level",
+                    focusArea = "Problem Solving"))
+
+    // Mock getPendingBattlesForUser to return the mock battle
+    `when`(mockBattleRepository.getPendingBattlesForUser(eq("testUser"), any(), any())).thenAnswer {
+      val callback = it.getArgument<(List<SpeechBattle>) -> Unit>(1)
+      callback(listOf(mockBattle))
+      null
+    }
+
+    `when`(
+            mockBattleRepository.updateBattleStatus(
+                eq("battle2"), eq(BattleStatus.CANCELLED), any()))
+        .thenAnswer { invocation ->
+          val callback = invocation.getArgument<(Boolean) -> Unit>(2)
+          callback.invoke(true) // Simulate a successful update
+          null
+        }
+
+    // Act
+    composeTestRule.setContent {
+      ViewFriendsScreen(mockNavigationActions, userProfileViewModel, battleViewModel)
+    }
+
+    // Wait for UI to render
+    composeTestRule.waitForIdle()
+
+    // Click on the friend with UID "2" to open the BattlePopup
+    composeTestRule.onNodeWithTag("viewFriendsItem#2").performClick()
+
+    // Verify the BattlePopup title
+    composeTestRule
+        .onNodeWithTag("battlePopupTitle")
+        .assertExists("BattlePopup title does not exist")
+        .assertIsDisplayed()
+        .assertTextEquals("Pending Battle Request from Jane Doe")
+
+    // Verify the BattlePopup description
+    val expectedDescription =
+        """
+        Interview Battle Context: Mock Interview for Software Engineer at TechCorp.
+        Job description: Solve coding problems under pressure.
+    """
+            .trimIndent()
+
+    composeTestRule
+        .onNodeWithTag("battlePopupDescription")
+        .assertExists("BattlePopup description does not exist")
+        .assertIsDisplayed()
+        .assertTextEquals(expectedDescription)
+
+    // Click the decline button
+    composeTestRule.onNodeWithTag("battlePopupDeclineButton").performClick()
+
+    // Verify that updateBattleStatus was called with correct parameters
+    verify(mockBattleRepository)
+        .updateBattleStatus(eq("battle2"), eq(BattleStatus.CANCELLED), any())
+
+    // Assert that the BattlePopup is dismissed
+    composeTestRule.onNodeWithTag("battlePopupTitle").assertDoesNotExist()
   }
 }

--- a/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/speechBattle/BattleViewModel.kt
@@ -1,6 +1,8 @@
 package com.github.se.orator.model.speechBattle
 
+import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -80,7 +82,7 @@ class BattleViewModel(
    *
    * @param battleId The ID of the battle to accept.
    */
-  fun acceptBattle(battleId: String) {
+  fun acceptBattle(battleId: String, localContext: Context? = null) {
     val currentUserUid = userProfileViewModel.userProfile.value?.uid ?: return
 
     // Use getFriendUid to determine the friend's UID
@@ -94,6 +96,10 @@ class BattleViewModel(
               if (battle != null) {
                 // Set the practice context for the battle
                 apiLinkViewModel.updatePracticeContext(battle.context)
+
+                if (localContext != null) {
+                  Toast.makeText(localContext, "Battle accepted!", Toast.LENGTH_SHORT).show()
+                }
 
                 // Navigate to the battle chat screen with the battleId and userId
                 navigationActions.navigateToBattleScreen(battleId, currentUserUid)
@@ -119,10 +125,13 @@ class BattleViewModel(
    *
    * @param battleId The ID of the battle to decline.
    */
-  fun declineBattle(battleId: String) {
+  fun declineBattle(battleId: String, localContext: Context? = null) {
     battleRepository.updateBattleStatus(battleId, BattleStatus.CANCELLED) { success ->
       if (success) {
         // Battle declined successfully
+        if (localContext != null) {
+          Toast.makeText(localContext, "Battle declined.", Toast.LENGTH_SHORT).show()
+        }
       } else {
         Log.e("BattleViewModel", "Failed to decline battle")
       }

--- a/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
@@ -768,11 +768,15 @@ fun BattlePopup(
 }
 
 /**
- * Builds a one-line description of the battle based on the [InterviewContext].
+ * Builds a short description of the battle based on the [InterviewContext].
  *
  * @param context The [InterviewContext] containing battle details.
- * @return A one-line description string.
+ * @return A short description string.
  */
 fun buildBattleDescription(context: InterviewContext): String {
-  return "Battle Context: ${context.interviewType} for ${context.targetPosition} at ${context.companyName}."
+  return """
+      Interview Battle Context: ${context.interviewType} for ${context.targetPosition} at ${context.companyName}.
+      Job description: ${context.jobDescription}
+      """
+      .trimIndent()
 }

--- a/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
@@ -390,20 +390,14 @@ fun ViewFriendsScreen(
                     onAccept = {
 
                       // Handle battle acceptance
-                      battleViewModel?.acceptBattle(battle.battleId)
+                      battleViewModel?.acceptBattle(battle.battleId, localContext)
                       selectedBattle = null
-
-                      // Show a toast
-                      Toast.makeText(localContext, "Battle accepted!", Toast.LENGTH_SHORT).show()
                     },
                     onDecline = {
 
                       // Handle battle decline
-                      battleViewModel?.declineBattle(battle.battleId)
+                      battleViewModel?.declineBattle(battle.battleId, localContext)
                       selectedBattle = null
-
-                      // Show a toast
-                      Toast.makeText(localContext, "Battle declined.", Toast.LENGTH_SHORT).show()
                     },
                     onDismiss = {
                       // Handle dialog dismissal

--- a/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
@@ -403,7 +403,7 @@ fun ViewFriendsScreen(
                       selectedBattle = null
 
                       // Show a toast
-                      Toast.makeText(localContext, "Battle accepted!", Toast.LENGTH_SHORT).show()
+                      Toast.makeText(localContext, "Battle declined.", Toast.LENGTH_SHORT).show()
                     },
                     onDismiss = {
                       // Handle dialog dismissal

--- a/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -74,11 +75,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.orator.R
 import com.github.se.orator.model.profile.UserProfile
 import com.github.se.orator.model.profile.UserProfileViewModel
+import com.github.se.orator.model.speaking.InterviewContext
+import com.github.se.orator.model.speechBattle.BattleStatus
 import com.github.se.orator.model.speechBattle.BattleViewModel
 import com.github.se.orator.model.speechBattle.SpeechBattle
 import com.github.se.orator.ui.navigation.BottomNavigationMenu
@@ -114,6 +118,9 @@ fun ViewFriendsScreen(
     userProfileViewModel: UserProfileViewModel,
     battleViewModel: BattleViewModel? = null // Optional ViewModel for battle management
 ) {
+
+  val localContext = LocalContext.current
+
   // State variables
   val friendsProfiles by userProfileViewModel.friendsProfiles.collectAsState()
   val recReqProfiles by userProfileViewModel.recReqProfiles.collectAsState()
@@ -137,6 +144,9 @@ fun ViewFriendsScreen(
 
   // New state variable for Friend Requests expansion
   var isFriendRequestsExpanded by remember { mutableStateOf(true) }
+
+  // State for managing the popup
+  var selectedBattle by remember { mutableStateOf<SpeechBattle?>(null) }
 
   LaunchedEffect(Unit) { battleViewModel?.fetchPendingBattlesForUser() }
 
@@ -344,15 +354,21 @@ fun ViewFriendsScreen(
                       // Display the list of friends if any match the search query
                       items(filteredFriends) { friend ->
                         val hasPendingBattle = friend.uid in challengerBattleMap.keys
+
+                        val pendingBattle =
+                            pendingBattles.find {
+                              it.challenger == friend.uid && it.status == BattleStatus.PENDING
+                            }
+
                         FriendItem(
                             friend = friend,
                             hasPendingBattle = hasPendingBattle,
                             userProfileViewModel = userProfileViewModel,
                             onProfilePictureClick = { selectedFriend = it },
                             onClick = { selectedFriend ->
-                              if (hasPendingBattle) {
-                                // Accept battle and navigate to battle screen
-                                battleViewModel?.acceptBattle(challengerBattleMap[friend.uid]!!)
+                              if (hasPendingBattle && pendingBattle != null) {
+                                // Show the popup with battle details
+                                selectedBattle = pendingBattle
                               } else {
                                 // Navigate to create battle screen
                                 navigationActions.navigateToSendBattleScreen(selectedFriend.uid)
@@ -361,6 +377,39 @@ fun ViewFriendsScreen(
                       }
                     }
                   }
+
+              // Display the BattlePopup if a battle is selected
+              selectedBattle?.let { battle ->
+                // Extract the InterviewContext from the SpeechBattle
+                val battleContext = battle.context
+                // Get the challenger's name
+                val challengerName = userProfileViewModel.getName(battle.challenger)
+                BattlePopup(
+                    challengerName = challengerName,
+                    interviewContext = battleContext,
+                    onAccept = {
+
+                      // Handle battle acceptance
+                      battleViewModel?.acceptBattle(battle.battleId)
+                      selectedBattle = null
+
+                      // Show a toast
+                      Toast.makeText(localContext, "Battle accepted!", Toast.LENGTH_SHORT).show()
+                    },
+                    onDecline = {
+
+                      // Handle battle decline
+                      battleViewModel?.declineBattle(battle.battleId)
+                      selectedBattle = null
+
+                      // Show a toast
+                      Toast.makeText(localContext, "Battle accepted!", Toast.LENGTH_SHORT).show()
+                    },
+                    onDismiss = {
+                      // Handle dialog dismissal
+                      selectedBattle = null
+                    })
+              }
 
               // Dialog to display the enlarged profile picture
               if (selectedFriend != null && !selectedFriend!!.profilePic.isNullOrEmpty()) {
@@ -636,4 +685,94 @@ fun FriendRequestItem(friendRequest: UserProfile, userProfileViewModel: UserProf
                   }
             }
       }
+}
+
+/**
+ * A composable function that displays a popup dialog for a pending battle.
+ *
+ * @param challengerName The name of the challenger.
+ * @param interviewContext The [InterviewContext] containing details about the battle.
+ * @param onAccept Callback invoked when the user accepts the battle.
+ * @param onDecline Callback invoked when the user declines the battle.
+ * @param onDismiss Callback invoked when the dialog is dismissed.
+ */
+@Composable
+fun BattlePopup(
+    challengerName: String,
+    interviewContext: InterviewContext,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onDismiss: () -> Unit
+) {
+  AlertDialog(
+      onDismissRequest = onDismiss,
+      title = {
+        // Centered Title with OnSurface Color
+        Text(
+            text = "Pending Battle Request from $challengerName",
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.titleMedium,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(bottom = AppDimensions.paddingSmall)
+                    .testTag("battlePopupTitle"))
+      },
+      text = {
+        // Centered Text with Small Size and OnSurface Color
+        Text(
+            text = buildBattleDescription(interviewContext),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(horizontal = AppDimensions.paddingSmall)
+                    .testTag("battlePopupDescription"))
+      },
+      confirmButton = {
+        // Centered Row for Accept and Decline Icons
+        Row(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .padding(top = AppDimensions.paddingSmall)
+                    .testTag("battlePopupActions"),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically) {
+              // Accept Icon
+              IconButton(
+                  onClick = onAccept,
+                  modifier =
+                      Modifier.size(AppDimensions.iconSizeMedium)
+                          .testTag("battlePopupAcceptButton")) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = "Accept Battle",
+                        tint = Color.Green)
+                  }
+              // Decline Icon
+              IconButton(
+                  onClick = onDecline,
+                  modifier =
+                      Modifier.size(AppDimensions.iconSizeMedium)
+                          .testTag("battlePopupDeclineButton")) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Decline Battle",
+                        tint = Color.Red)
+                  }
+            }
+      },
+      dismissButton = {} // Empty as the actions are in confirmButton
+      )
+}
+
+/**
+ * Builds a one-line description of the battle based on the [InterviewContext].
+ *
+ * @param context The [InterviewContext] containing battle details.
+ * @return A one-line description string.
+ */
+fun buildBattleDescription(context: InterviewContext): String {
+  return "Battle Context: ${context.interviewType} for ${context.targetPosition} at ${context.companyName}."
 }


### PR DESCRIPTION
This PR introduces the popup screen for incoming battles. When clicking on the notification, a dialog appears with options to accept or decline the battle, while displaying information about the battle. I also ensured appropriate toasts are displayed to confirm whether the battle was accepted or rejected that confirm the user's choice . Additionally, I added tests to verify the dialog's behavior and functionality. This closes #301
![popup](https://github.com/user-attachments/assets/03277f69-cc34-452c-a0d5-478b4429a4e4)  