### PR TITLE
Enable Real time updates for pending battle requests

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/friends/FriendsUITests.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/friends/FriendsUITests.kt
@@ -843,7 +843,7 @@ class FriendsUITests {
           null
         }
         .`when`(mockBattleRepository)
-        .getPendingBattlesForUser(any(), any(), any())
+        .listenForPendingBattles(any(), any())
 
     // Mock getBattleById to return the specific battle
     `when`(mockBattleRepository.getBattleById(eq("battle1"), any())).thenAnswer { invocation ->
@@ -941,7 +941,7 @@ class FriendsUITests {
                     focusArea = "Problem Solving"))
 
     // Mock getPendingBattlesForUser to return the mock battle
-    `when`(mockBattleRepository.getPendingBattlesForUser(eq("testUser"), any(), any())).thenAnswer {
+    `when`(mockBattleRepository.listenForPendingBattles(eq("testUser"), any())).thenAnswer {
       val callback = it.getArgument<(List<SpeechBattle>) -> Unit>(1)
       callback(listOf(mockBattle))
       null

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
@@ -46,14 +46,6 @@ class UserProfileViewModel(internal val repository: UserProfileRepository) : Vie
   private val isLoading_ = MutableStateFlow(true)
   val isLoading: StateFlow<Boolean> = isLoading_.asStateFlow()
 
-  private val pendingBattles_ = MutableStateFlow<Map<String, String>>(emptyMap())
-  val pendingBattles: StateFlow<Map<String, String>> = pendingBattles_.asStateFlow()
-
-  private val friendsWithPendingBattles_ =
-      MutableStateFlow<List<Pair<UserProfile, String>>>(emptyList())
-  val friendsWithPendingBattles: StateFlow<List<Pair<UserProfile, String>>> =
-      friendsWithPendingBattles_.asStateFlow()
-
   // Queue of the last ten analysis data
   private val recentData_ = MutableStateFlow<ArrayDeque<AnalysisData>>(ArrayDeque())
   val recentData: StateFlow<ArrayDeque<AnalysisData>> = recentData_.asStateFlow()

--- a/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/friends/FriendsScreen.kt
@@ -146,7 +146,7 @@ fun ViewFriendsScreen(
   // State for managing the popup
   var selectedBattle by remember { mutableStateOf<SpeechBattle?>(null) }
 
-  LaunchedEffect(Unit) { battleViewModel?.fetchPendingBattlesForUser() }
+  LaunchedEffect(Unit) { battleViewModel?.listenForPendingBattles() }
 
   // Collect the pending battles as state, fallback to an empty list if battleViewModel is null
   val pendingBattles by


### PR DESCRIPTION
# Enable Real-Time Updates for Pending Battle Requests

This PR introduces real-time updates for pending battle requests, improving the user experience by ensuring that users no longer need to leave and reopen the Friends screen to see updates, solving https://github.com/SWENT-TEAM17/OratorAI/issues/305.

## Changes

### 1. Real-Time Updates for Pending Battles
- Integrated the existing `listenForPendingBattles` method from `BattleViewModel` and `BattleRepositoryFirestore`.
- Previously, `fetchPendingBattlesForUser` was called, requiring users to manually refresh or re-enter the screen to see updated data. 
- By switching to `listenForPendingBattles`, pending battle requests are now updated in real-time, ensuring a smoother and more seamless user experience.

### 2. Cleanup in `UserProfileViewModel`
- Removed unused variables from `UserProfileViewModel` to enhance code clarity and maintainability.

## Benefits
- **Real-Time Synchronization:** Ensures pending battle requests are dynamically updated while users stay on the Friends screen.
- **Code Cleanup:** Removes unnecessary variables, improving code maintainability and reducing potential confusion.

This PR ensures a more dynamic and efficient interaction flow for users and improves overall code quality.

---

### Let me know if further adjustments are required!