### PR TITLE
Fix errors on speaking screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/model/symblAi/SymblApiClientTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/model/symblAi/SymblApiClientTest.kt
@@ -143,9 +143,9 @@ class SymblApiClientTest {
 
       val expectedTranscription =
           """
-            You said: Thank you for reaching out to us.
-            You said: All lines are currently busy.
-            You said: Your call is very important to us.
+            Thank you for reaching out to us.
+            All lines are currently busy.
+            Your call is very important to us.
         """
               .trimIndent()
 

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingError.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingError.kt
@@ -1,5 +1,9 @@
 package com.github.se.orator.model.symblAi
 
+
+/**
+ * Enum class to represent the different errors that can occur during the processing of the user's speech.
+ */
 enum class SpeakingError {
   NO_ERROR,
   CREDENTIALS_ERROR,
@@ -14,14 +18,21 @@ enum class SpeakingError {
   override fun toString(): String {
     return when (this) {
       NO_ERROR -> "No error"
-      CREDENTIALS_ERROR -> "There was an error with the SymblAI data"
-      ACCESS_TOKEN_ERROR -> "There was an error with the SymblAI data"
-      HTTP_REQUEST_ERROR -> "There was an error when issuing the HTTP request"
-      JOB_PROCESSING_ERROR -> "There was an error processing the job"
-      MISSING_CONV_ID_ERROR -> "There was an error with the SymblAI data"
-      JSON_PARSING_ERROR -> "There was an error processing the received data from SymblAI"
-      NO_MESSAGES_FOUND_ERROR -> "There was an error processing the received data from SymblAI"
-      NO_ANALYTICS_FOUND_ERROR -> "There was an error processing the received data from SymblAI"
+      CREDENTIALS_ERROR -> Companion.STRING_SYMBL_DATA_ERROR
+      ACCESS_TOKEN_ERROR -> Companion.STRING_SYMBL_DATA_ERROR
+      HTTP_REQUEST_ERROR -> Companion.STRING_HTTP_ERROR
+      JOB_PROCESSING_ERROR -> Companion.STRING_SYMBL_JOB_ERROR
+      MISSING_CONV_ID_ERROR -> Companion.STRING_SYMBL_DATA_ERROR
+      JSON_PARSING_ERROR -> Companion.STRING_SYMBL_PROCESSING_ERROR
+      NO_MESSAGES_FOUND_ERROR -> Companion.STRING_SYMBL_PROCESSING_ERROR
+      NO_ANALYTICS_FOUND_ERROR -> Companion.STRING_SYMBL_PROCESSING_ERROR
     }
+  }
+
+  companion object {
+    const val STRING_HTTP_ERROR = "There was an error when issuing the HTTP request"
+    const val STRING_SYMBL_DATA_ERROR = "There was an error with the SymblAI data"
+    const val STRING_SYMBL_JOB_ERROR = "There was an error processing the job"
+    const val STRING_SYMBL_PROCESSING_ERROR = "There was an error processing the data from SymblAI"
   }
 }

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingError.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingError.kt
@@ -9,5 +9,19 @@ enum class SpeakingError {
   MISSING_CONV_ID_ERROR,
   JSON_PARSING_ERROR,
   NO_MESSAGES_FOUND_ERROR,
-  NO_ANALYTICS_FOUND_ERROR
+  NO_ANALYTICS_FOUND_ERROR;
+
+  override fun toString(): String {
+    return when (this) {
+      NO_ERROR -> "No error"
+      CREDENTIALS_ERROR -> "There was an error with the SymblAI data"
+      ACCESS_TOKEN_ERROR -> "There was an error with the SymblAI data"
+      HTTP_REQUEST_ERROR -> "There was an error when issuing the HTTP request"
+      JOB_PROCESSING_ERROR -> "There was an error processing the job"
+      MISSING_CONV_ID_ERROR -> "There was an error with the SymblAI data"
+      JSON_PARSING_ERROR -> "There was an error processing the received data from SymblAI"
+      NO_MESSAGES_FOUND_ERROR -> "There was an error processing the received data from SymblAI"
+      NO_ANALYTICS_FOUND_ERROR -> "There was an error processing the received data from SymblAI"
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingError.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingError.kt
@@ -1,8 +1,8 @@
 package com.github.se.orator.model.symblAi
 
-
 /**
- * Enum class to represent the different errors that can occur during the processing of the user's speech.
+ * Enum class to represent the different errors that can occur during the processing of the user's
+ * speech.
  */
 enum class SpeakingError {
   NO_ERROR,

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SpeakingViewModel.kt
@@ -159,6 +159,8 @@ class SpeakingViewModel(
               _analysisData.value = ad
               userProfileViewModel.addNewestData(_analysisData.value!!)
               userProfileViewModel.updateMetricMean()
+              // Reset the error state
+              _analysisError.value = SpeakingError.NO_ERROR
             },
             onFailure = { error -> _analysisError.value = error })
         repository.startRecording(audioFile)

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
@@ -131,7 +131,7 @@ class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttp
           }
 
           // Append the disfluencies before the transcribed message
-          textBuilder.append("You said: $disfluencies$messageText\n")
+          textBuilder.append("$disfluencies$messageText\n")
 
           val sentiment = messageObject.optJSONObject("sentiment")
           if (sentiment != null) {

--- a/app/src/test/java/com/github/se/orator/model/symblAi/SpeakingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/symblAi/SpeakingViewModelTest.kt
@@ -247,31 +247,36 @@ class SpeakingViewModelTest {
     assertEquals("", updatedPrompt["transcription"]) // Verify that transcription remains empty
   }
 
-    /**
-     * Test that the [SpeakingError] enum string constants (holding the error message
-     * to display) are correct.
-     */
-    @Test
-    fun symblErrorConstStringsAreCorrect() {
-        assert(SpeakingError.STRING_SYMBL_DATA_ERROR == "There was an error with the SymblAI data")
-        assert(SpeakingError.STRING_HTTP_ERROR == "There was an error when issuing the HTTP request")
-        assert(SpeakingError.STRING_SYMBL_JOB_ERROR == "There was an error processing the job")
-        assert(SpeakingError.STRING_SYMBL_PROCESSING_ERROR == "There was an error processing the data from SymblAI")
-    }
+  /**
+   * Test that the [SpeakingError] enum string constants (holding the error message to display) are
+   * correct.
+   */
+  @Test
+  fun symblErrorConstStringsAreCorrect() {
+    assert(SpeakingError.STRING_SYMBL_DATA_ERROR == "There was an error with the SymblAI data")
+    assert(SpeakingError.STRING_HTTP_ERROR == "There was an error when issuing the HTTP request")
+    assert(SpeakingError.STRING_SYMBL_JOB_ERROR == "There was an error processing the job")
+    assert(
+        SpeakingError.STRING_SYMBL_PROCESSING_ERROR ==
+            "There was an error processing the data from SymblAI")
+  }
 
-    /**
-     * Test that the toString() method of the [SpeakingError] enum provides the correct string
-     */
-    @Test
-    fun symblErrorToStringProvidesCorrectString() {
-        assert(SpeakingError.NO_ERROR.toString() == "No error")
-        assert(SpeakingError.CREDENTIALS_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
-        assert(SpeakingError.ACCESS_TOKEN_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
-        assert(SpeakingError.HTTP_REQUEST_ERROR.toString() == SpeakingError.STRING_HTTP_ERROR)
-        assert(SpeakingError.JOB_PROCESSING_ERROR.toString() == SpeakingError.STRING_SYMBL_JOB_ERROR)
-        assert(SpeakingError.MISSING_CONV_ID_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
-        assert(SpeakingError.JSON_PARSING_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
-        assert(SpeakingError.NO_MESSAGES_FOUND_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
-        assert(SpeakingError.NO_ANALYTICS_FOUND_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
-    }
+  /** Test that the toString() method of the [SpeakingError] enum provides the correct string */
+  @Test
+  fun symblErrorToStringProvidesCorrectString() {
+    assert(SpeakingError.NO_ERROR.toString() == "No error")
+    assert(SpeakingError.CREDENTIALS_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
+    assert(SpeakingError.ACCESS_TOKEN_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
+    assert(SpeakingError.HTTP_REQUEST_ERROR.toString() == SpeakingError.STRING_HTTP_ERROR)
+    assert(SpeakingError.JOB_PROCESSING_ERROR.toString() == SpeakingError.STRING_SYMBL_JOB_ERROR)
+    assert(SpeakingError.MISSING_CONV_ID_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
+    assert(
+        SpeakingError.JSON_PARSING_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
+    assert(
+        SpeakingError.NO_MESSAGES_FOUND_ERROR.toString() ==
+            SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
+    assert(
+        SpeakingError.NO_ANALYTICS_FOUND_ERROR.toString() ==
+            SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
+  }
 }

--- a/app/src/test/java/com/github/se/orator/model/symblAi/SpeakingViewModelTest.kt
+++ b/app/src/test/java/com/github/se/orator/model/symblAi/SpeakingViewModelTest.kt
@@ -246,4 +246,32 @@ class SpeakingViewModelTest {
     assertEquals("1", updatedPrompt["transcribed"]) // Verify that transcribed was set to 0
     assertEquals("", updatedPrompt["transcription"]) // Verify that transcription remains empty
   }
+
+    /**
+     * Test that the [SpeakingError] enum string constants (holding the error message
+     * to display) are correct.
+     */
+    @Test
+    fun symblErrorConstStringsAreCorrect() {
+        assert(SpeakingError.STRING_SYMBL_DATA_ERROR == "There was an error with the SymblAI data")
+        assert(SpeakingError.STRING_HTTP_ERROR == "There was an error when issuing the HTTP request")
+        assert(SpeakingError.STRING_SYMBL_JOB_ERROR == "There was an error processing the job")
+        assert(SpeakingError.STRING_SYMBL_PROCESSING_ERROR == "There was an error processing the data from SymblAI")
+    }
+
+    /**
+     * Test that the toString() method of the [SpeakingError] enum provides the correct string
+     */
+    @Test
+    fun symblErrorToStringProvidesCorrectString() {
+        assert(SpeakingError.NO_ERROR.toString() == "No error")
+        assert(SpeakingError.CREDENTIALS_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
+        assert(SpeakingError.ACCESS_TOKEN_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
+        assert(SpeakingError.HTTP_REQUEST_ERROR.toString() == SpeakingError.STRING_HTTP_ERROR)
+        assert(SpeakingError.JOB_PROCESSING_ERROR.toString() == SpeakingError.STRING_SYMBL_JOB_ERROR)
+        assert(SpeakingError.MISSING_CONV_ID_ERROR.toString() == SpeakingError.STRING_SYMBL_DATA_ERROR)
+        assert(SpeakingError.JSON_PARSING_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
+        assert(SpeakingError.NO_MESSAGES_FOUND_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
+        assert(SpeakingError.NO_ANALYTICS_FOUND_ERROR.toString() == SpeakingError.STRING_SYMBL_PROCESSING_ERROR)
+    }
 }


### PR DESCRIPTION
This pull requests fixes the bug where the error would not disappear in `SpeakingScreen.kt`, and also improves some `String` elements.

Improvements to error handling and user feedback:

* `SpeakingError.kt`: Added a `toString` method to the `SpeakingError` enum class to provide more descriptive error messages.
* `SpeakingViewModel.kt`: Reset the error state to `NO_ERROR` after successfully updating the analysis data and metrics.

Text formatting adjustments:

* `SymblApiClient.kt`: Removed the redundant "You said :" prefix from the transcribed message.