### PR TITLE
Create online screen for BOTI relocation

### DIFF
--- a/app/src/androidTest/java/com/github/se/orator/ui/mainscreen/OnlineScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/mainscreen/OnlineScreenTest.kt
@@ -1,0 +1,3 @@
+package com.github.se.orator.ui.mainscreen
+
+class OnlineScreenTest {}

--- a/app/src/androidTest/java/com/github/se/orator/ui/mainscreen/OnlineScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/orator/ui/mainscreen/OnlineScreenTest.kt
@@ -1,3 +1,54 @@
-package com.github.se.orator.ui.mainscreen
+package com.github.se.orator.ui.mainScreen
 
-class OnlineScreenTest {}
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.se.orator.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class OnlineScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+  }
+
+  @Test
+  fun onlineScreen_displaysTitleCorrectly() {
+    composeTestRule.setContent { OnlineScreen(navigationActions = navigationActions) }
+
+    composeTestRule.onNodeWithTag("onlineScreenText1").assertTextEquals("Battle online")
+    composeTestRule.onNodeWithTag("onlineScreenText2").assertTextEquals("with friends!")
+  }
+
+  @Test
+  fun onlineScreen_toolbarButtons_areDisplayedAndClickable() {
+    composeTestRule.setContent { OnlineScreen(navigationActions = navigationActions) }
+
+    composeTestRule
+        .onNodeWithTag("toolbar")
+        .onChildAt(0)
+        .assertTextEquals("Popular")
+        .assertHasClickAction()
+
+    composeTestRule
+        .onNodeWithTag("toolbar")
+        .onChildAt(1)
+        .assertTextEquals("Online")
+        .assertHasClickAction()
+  }
+
+  @Test
+  fun onlineScreen_modeCard_navigatesToFriends() {
+
+    composeTestRule.setContent { OnlineScreen(navigationActions = navigationActions) }
+
+    composeTestRule.onNodeWithText("Battle Of The Interviews").performClick()
+  }
+}

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -48,6 +48,7 @@ import com.github.se.orator.ui.friends.AddFriendsScreen
 import com.github.se.orator.ui.friends.LeaderboardScreen
 import com.github.se.orator.ui.friends.ViewFriendsScreen
 import com.github.se.orator.ui.mainScreen.MainScreen
+import com.github.se.orator.ui.mainScreen.OnlineScreen
 import com.github.se.orator.ui.navigation.NavigationActions
 import com.github.se.orator.ui.navigation.Route
 import com.github.se.orator.ui.navigation.Screen
@@ -219,6 +220,7 @@ fun OratorApp(
           // Main/home flow
           navigation(startDestination = Screen.HOME, route = Route.HOME) {
             composable(Screen.HOME) { MainScreen(navigationActions) }
+            composable(Screen.ONLINE_SCREEN) { OnlineScreen(navigationActions) }
             composable(Screen.SPEAKING_JOB_INTERVIEW) {
               SpeakingJobInterviewModule(navigationActions, chatViewModel, apiLinkViewModel)
             }

--- a/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.github.se.orator.R
 import com.github.se.orator.ui.navigation.BottomNavigationMenu
@@ -53,22 +54,7 @@ fun MainScreen(navigationActions: NavigationActions) {
       modifier = Modifier.fillMaxSize(),
       content = { padding ->
         Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-          Text(
-              modifier =
-                  Modifier.padding(start = AppDimensions.paddingXXLarge)
-                      .padding(top = AppDimensions.paddingXXXLarge)
-                      .testTag("mainScreenText1"),
-              text = "Find your",
-              style = AppTypography.largeTitleStyle, // Apply custom style for title
-              color = MaterialTheme.colorScheme.secondary)
-
-          Text(
-              modifier =
-                  Modifier.padding(start = AppDimensions.paddingXXLarge).testTag("mainScreenText2"),
-              text = "practice mode",
-              style = AppTypography.largeTitleStyle, // Apply custom style for subtitle
-              fontWeight = FontWeight.Bold,
-              color = MaterialTheme.colorScheme.primary)
+          MainTitle("mainScreenText1", "Find your", "mainScreenText2", "practice mode")
 
           ButtonRow(navigationActions)
 
@@ -95,9 +81,9 @@ fun ButtonRow(navigationActions: NavigationActions) {
       horizontalArrangement =
           Arrangement.spacedBy(AppDimensions.spacingXLarge, Alignment.CenterHorizontally),
   ) {
-    SectionButton("Popular") {
-      // Do nothing, stays on the same screen
-    }
+    SectionButton("Popular", {}, true)
+
+    SectionButton("Online", { navigationActions.navigateTo(Screen.ONLINE_SCREEN) }, false)
   }
 }
 
@@ -107,11 +93,18 @@ fun ButtonRow(navigationActions: NavigationActions) {
  * The implementation of a button
  */
 @Composable
-fun SectionButton(text: String, onClick: () -> Unit) {
+fun SectionButton(text: String, onClick: () -> Unit, isSelected: Boolean) {
+  var selectedColor = MaterialTheme.colorScheme.secondary
+  var boldIfSelected = FontWeight.Normal
+  if (isSelected) {
+    selectedColor = MaterialTheme.colorScheme.primary
+    boldIfSelected = FontWeight.Bold
+  }
   TextButton(onClick = onClick, modifier = Modifier.testTag("button")) {
     Text(
         text = text,
-        color = MaterialTheme.colorScheme.secondary,
+        color = selectedColor,
+        fontWeight = boldIfSelected,
         fontSize = AppFontSizes.buttonText)
   }
 }
@@ -144,6 +137,8 @@ fun AnimatedCards(navigationActions: NavigationActions) {
         items(modes) { mode ->
           ModeCard(
               text = mode.text,
+              note = "",
+              withNote = false,
               painter = painterResource(mode.imageRes),
               visible = true,
               onCardClick = {
@@ -156,6 +151,7 @@ fun AnimatedCards(navigationActions: NavigationActions) {
 
 /**
  * @param text the text describing each mode
+ * @param note an additional note
  * @param painter the image displayed for each mode
  * @param visible boolean used for the animation effect
  * @param onCardClick callback function for a on click event
@@ -163,7 +159,14 @@ fun AnimatedCards(navigationActions: NavigationActions) {
  * The implementation of a mode card
  */
 @Composable
-fun ModeCard(text: String, painter: Painter, visible: Boolean, onCardClick: () -> Unit) {
+fun ModeCard(
+    text: String,
+    note: String,
+    withNote: Boolean,
+    painter: Painter,
+    visible: Boolean,
+    onCardClick: () -> Unit
+) {
   AnimatedVisibility(
       visible = visible,
       enter = slideInVertically() + fadeIn(),
@@ -195,7 +198,47 @@ fun ModeCard(text: String, painter: Painter, visible: Boolean, onCardClick: () -
                         Modifier.padding(AppDimensions.paddingMedium)
                             .align(Alignment.CenterHorizontally),
                     color = MaterialTheme.colorScheme.primary)
+                if (withNote) {
+                  Text(
+                      text = note,
+                      fontSize = AppFontSizes.cardTitle,
+                      fontStyle = FontStyle.Italic,
+                      modifier =
+                          Modifier.padding(
+                                  start = AppDimensions.paddingMedium,
+                                  end = AppDimensions.paddingMedium,
+                                  bottom = AppDimensions.paddingMedium)
+                              .align(Alignment.CenterHorizontally),
+                      color = MaterialTheme.colorScheme.secondary)
+                }
               }
             }
       }
+}
+
+/**
+ * @param testTagText1 test tag for the first text
+ * @param text1 first text of the title
+ * @param testTagText2 test tag for the second text
+ * @param text2 second text of the title
+ *
+ * Composable for the title on the main screen and online screen
+ */
+@Composable
+fun MainTitle(testTagText1: String, text1: String, testTagText2: String, text2: String) {
+  Text(
+      modifier =
+          Modifier.padding(start = AppDimensions.paddingXXLarge)
+              .padding(top = AppDimensions.paddingXXXLarge)
+              .testTag(testTagText1),
+      text = text1,
+      style = AppTypography.largeTitleStyle, // Apply custom style for title
+      color = MaterialTheme.colorScheme.secondary)
+
+  Text(
+      modifier = Modifier.padding(start = AppDimensions.paddingXXLarge).testTag(testTagText2),
+      text = text2,
+      style = AppTypography.largeTitleStyle, // Apply custom style for subtitle
+      fontWeight = FontWeight.Bold,
+      color = MaterialTheme.colorScheme.primary)
 }

--- a/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
@@ -94,12 +94,9 @@ fun ButtonRow(navigationActions: NavigationActions) {
  */
 @Composable
 fun SectionButton(text: String, onClick: () -> Unit, isSelected: Boolean) {
-  var selectedColor = MaterialTheme.colorScheme.secondary
-  var boldIfSelected = FontWeight.Normal
-  if (isSelected) {
-    selectedColor = MaterialTheme.colorScheme.primary
-    boldIfSelected = FontWeight.Bold
-  }
+  val selectedColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary
+    val boldIfSelected = if (isSelected) FontWeight.Bold else FontWeight.Normal
+}
   TextButton(onClick = onClick, modifier = Modifier.testTag("button")) {
     Text(
         text = text,

--- a/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
@@ -94,9 +94,9 @@ fun ButtonRow(navigationActions: NavigationActions) {
  */
 @Composable
 fun SectionButton(text: String, onClick: () -> Unit, isSelected: Boolean) {
-  val selectedColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary
-    val boldIfSelected = if (isSelected) FontWeight.Bold else FontWeight.Normal
-}
+  val selectedColor =
+      if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary
+  val boldIfSelected = if (isSelected) FontWeight.Bold else FontWeight.Normal
   TextButton(onClick = onClick, modifier = Modifier.testTag("button")) {
     Text(
         text = text,

--- a/app/src/main/java/com/github/se/orator/ui/mainScreen/OnlineScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/mainScreen/OnlineScreen.kt
@@ -23,8 +23,8 @@ import com.github.se.orator.ui.navigation.Screen
 import com.github.se.orator.ui.theme.AppDimensions
 
 /**
- * The main screen's composable responsible to display the welcome text, the practice mode cards and
- * the toolbar containing buttons for different sections
+ * The online screen's composable responsible to display the welcome text, the BOTI card and the
+ * toolbar containing buttons for different sections
  */
 @Composable
 fun OnlineScreen(navigationActions: NavigationActions) {
@@ -64,7 +64,7 @@ fun OnlineScreen(navigationActions: NavigationActions) {
 }
 
 /**
- * The implementation of the toolbar containing the different selection buttons of the main screen
+ * The implementation of the toolbar containing the different selection buttons of the online screen
  */
 @Composable
 fun ButtonRowOnline(navigationActions: NavigationActions) {

--- a/app/src/main/java/com/github/se/orator/ui/mainScreen/OnlineScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/mainScreen/OnlineScreen.kt
@@ -1,0 +1,81 @@
+package com.github.se.orator.ui.mainScreen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import com.github.se.orator.R
+import com.github.se.orator.ui.navigation.BottomNavigationMenu
+import com.github.se.orator.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.Route
+import com.github.se.orator.ui.navigation.Screen
+import com.github.se.orator.ui.theme.AppDimensions
+
+/**
+ * The main screen's composable responsible to display the welcome text, the practice mode cards and
+ * the toolbar containing buttons for different sections
+ */
+@Composable
+fun OnlineScreen(navigationActions: NavigationActions) {
+  Scaffold(
+      modifier = Modifier.fillMaxSize(),
+      content = { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+          MainTitle("onlineScreenText1", "Battle online", "onlineScreenText2", "with friends!")
+
+          ButtonRowOnline(navigationActions)
+
+          LazyColumn(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(AppDimensions.paddingMedium),
+              contentPadding = PaddingValues(AppDimensions.paddingMedium)) {
+                // Online mode (BOTI) cards
+                item {
+                  ModeCard(
+                      "Battle Of The Interviews",
+                      "Click on a friend's profile to initiate",
+                      true,
+                      painterResource(R.drawable.speaking_interview),
+                      true) {
+                        navigationActions.navigateTo(Screen.FRIENDS)
+                      }
+                }
+              }
+        }
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = Route.HOME)
+      })
+}
+
+/**
+ * The implementation of the toolbar containing the different selection buttons of the main screen
+ */
+@Composable
+fun ButtonRowOnline(navigationActions: NavigationActions) {
+  Row(
+      modifier =
+          Modifier.testTag("toolbar").fillMaxWidth().padding(top = AppDimensions.paddingMedium),
+      horizontalArrangement =
+          Arrangement.spacedBy(AppDimensions.spacingXLarge, Alignment.CenterHorizontally),
+  ) {
+    SectionButton("Popular", { navigationActions.navigateTo(Screen.HOME) }, false)
+
+    SectionButton("Online", {}, true)
+  }
+}

--- a/app/src/main/java/com/github/se/orator/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/orator/ui/navigation/NavigationActions.kt
@@ -41,6 +41,7 @@ object Route {
   const val EVALUATION = "EvaluationScreen"
   const val OFFLINE_INTERVIEW_MODULE = "OfflineInterviewModule"
   const val OFFLINE_RECORDING_PROFILE = "OfflineRecordingProfile"
+  const val ONLINE = "Online"
 }
 
 object Screen {
@@ -75,6 +76,7 @@ object Screen {
   const val EVALUATION_SCREEN = "Evaluation Waiting Screen"
   const val OFFLINE_INTERVIEW_MODULE = "OfflineInterviewModule"
   const val OFFLINE_RECORDING_PROFILE = "OfflineRecordingProfile"
+  const val ONLINE_SCREEN = "Online Screen"
 }
 
 data class TopLevelDestination(


### PR DESCRIPTION
This PR introduces the Online Screen for the BOTI feature relocation. The screen is designed to display an obvious way for the user to initiate a battle. 

Created a New Online Screen

- Added OnlineScreen.kt under the mainScreen package.
- Implemented a scaffold layout with a MainTitle composable for titles (MainTitle was created in MainScreen.kt to avoid duplication for the same styled title in the two screens).
- Implemented a LazyColumn for displaying BOTI card.
- Added the bottom navigation bar.

Implemented UI Tests for Online Screen

- Added OnlineScreenTest.kt in the androidTest directory.
- Implemented tests that cover title display and toolbar button visibility and clickability.

Refactored Composables

- SectionButton: Added isSelected parameter for highlighting the screen that is selected.
- MainTitle: Abstracted title composable for reusability across screens.
- ModeCard: Enhanced to display an optional note beneath each card.

Navigation Updates

- Integrated the new ONLINE_SCREEN in the MainActivity navigation graph.
- Defined Screen.ONLINE_SCREEN and route constants in NavigationActions.kt.

Files created

- OnlineScreen.kt - New composable for the Online Screen.
- OnlineScreenTest.kt

Files changed

- MainActivity.kt - Added navigation to Online Screen.
- NavigationActions.kt - Defined constants for the new screen.
- MainScreen.kt - Added a button for navigating to the Online Screen.

Overview:
<img width="234" alt="mainScreenButton" src="https://github.com/user-attachments/assets/f58c4a0c-6ba1-4154-92d1-e8a2147dd8fc" />



<img width="258" alt="onlineScreen" src="https://github.com/user-attachments/assets/addbed56-ae8f-4a28-86b8-0c20ebe382ab" />


Related issues:
#308