### PR TITLE
Fix recurrent HTTP requests failures

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
@@ -248,7 +248,7 @@ class SymblApiClient(
             accessToken = accessToken,
             requestBody = requestBody)
 
-    urlCallRequestBlocking(
+    urlCallRequest(
         request = request,
         onSuccess = { response ->
           val jsonObject = JSONObject(response)

--- a/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
+++ b/app/src/main/java/com/github/se/orator/model/symblAi/SymblApiClient.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import com.github.se.orator.model.speaking.AnalysisData
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.FormBody
@@ -21,14 +22,24 @@ import org.json.JSONObject
 
 private const val CLASS_LOG_ID = "SymblApiClient"
 
+// Timeout duration for API calls
+private const val TIMEOUT_DURATION = 20L
+
 /**
  * The SymblApiClient class is responsible for making API calls to the Symbl.ai API.
  *
  * @param context The context of the application.
  * @param client The OkHttpClient instance to use for making API calls.
  */
-class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttpClient()) :
-    VoiceAnalysisApi {
+class SymblApiClient(
+    context: Context,
+    private val client: OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(TIMEOUT_DURATION, TimeUnit.SECONDS)
+            .readTimeout(TIMEOUT_DURATION, TimeUnit.SECONDS)
+            .writeTimeout(TIMEOUT_DURATION, TimeUnit.SECONDS)
+            .build()
+) : VoiceAnalysisApi {
 
   // Variables to hold Symbl.ai credentials
   private var symblAppId: String
@@ -237,7 +248,7 @@ class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttp
             accessToken = accessToken,
             requestBody = requestBody)
 
-    urlCallRequest(
+    urlCallRequestBlocking(
         request = request,
         onSuccess = { response ->
           val jsonObject = JSONObject(response)
@@ -455,15 +466,20 @@ class SymblApiClient(context: Context, private val client: OkHttpClient = OkHttp
       onSuccess: (String) -> Unit,
       onFailure: (SpeakingError) -> Unit
   ) {
-    client.newCall(request).execute().use { response ->
-      val responseData = response.body?.string() ?: "No Response"
-      Log.d(CLASS_LOG_ID, responseData)
-      if (response.isSuccessful && responseData.isNotEmpty()) {
-        onSuccess(responseData)
-      } else {
-        onFailure(SpeakingError.HTTP_REQUEST_ERROR)
-        Log.e(CLASS_LOG_ID, "HTTP request failed: $responseData")
+    try {
+      client.newCall(request).execute().use { response ->
+        val responseData = response.body?.string() ?: "No Response"
+        Log.d(CLASS_LOG_ID, responseData)
+        if (response.isSuccessful && responseData.isNotEmpty()) {
+          onSuccess(responseData)
+        } else {
+          onFailure(SpeakingError.HTTP_REQUEST_ERROR)
+          Log.e(CLASS_LOG_ID, "HTTP request failed: $responseData")
+        }
       }
+    } catch (e: IOException) {
+      Log.e(CLASS_LOG_ID, "Failed to fetch data", e)
+      onFailure(SpeakingError.HTTP_REQUEST_ERROR)
     }
   }
 }

--- a/app/src/main/java/com/github/se/orator/ui/network/ChatGPTService.kt
+++ b/app/src/main/java/com/github/se/orator/ui/network/ChatGPTService.kt
@@ -1,5 +1,6 @@
 package com.github.se.orator.ui.network
 
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -7,6 +8,9 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
+
+// Define a timeout duration for network calls
+private const val TIMEOUT_DURATION = 20L
 
 // Define the ChatGPTService interface
 interface ChatGPTService {
@@ -53,6 +57,9 @@ fun createChatGPTService(apiKey: String, organizationId: String): ChatGPTService
   // Create an OkHttpClient with logging and the API key header
   val client =
       OkHttpClient.Builder()
+          .connectTimeout(TIMEOUT_DURATION, TimeUnit.SECONDS)
+          .readTimeout(TIMEOUT_DURATION, TimeUnit.SECONDS)
+          .writeTimeout(TIMEOUT_DURATION, TimeUnit.SECONDS)
           .addInterceptor(logging)
           .addInterceptor { chain ->
             val request =


### PR DESCRIPTION
This PR simply increases the timeout value for the HTTP requests in `SymblApiClient.kt` and `ChatGPTService.kt`, to allow requests taking more time to actually arrive.
Also add an error handling mechanism for IOExceptions when calling `urlCallRequestBlocking` in `SymblApiClient.kt`.