### PR TITLE
fix: other user declines battle redirects to home screen

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/battle/BattleRequestSentScreen.kt
@@ -61,6 +61,10 @@ fun BattleRequestSentScreen(
       // Navigate to the battle screen
       battleViewModel.startBattle(battleId)
     }
+    if (battleStatus == BattleStatus.CANCELLED) {
+      Toast.makeText(context, "$friendName has declined the battle.", Toast.LENGTH_SHORT).show()
+      navigationActions.navigateTo(TopLevelDestinations.HOME)
+    }
   }
 
   // Handle cancellation when the user exits the app via ProcessLifecycleOwner


### PR DESCRIPTION
This PR is a continuation of #299. It implements the missing feature where declining a battle triggers a redirection to the home screen. This functionality has now been added. 


![Untitled video - Made with Clipchamp (1)](https://github.com/user-attachments/assets/18e147a4-cb96-4562-a196-a58669eb00d3)

