### PR TITLE
fix: dark mode for metrics display in feedback screen

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/overview/FeedbackScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/overview/FeedbackScreen.kt
@@ -171,6 +171,7 @@ fun FeedbackScreen(
                           Text(
                               text = "Your Performance Metrics:",
                               style = AppTypography.mediumTitleStyle,
+                              color = MaterialTheme.colorScheme.secondary,
                               modifier =
                                   Modifier.padding(AppDimensions.paddingMedium)
                                       .testTag("performanceMetricsTitle"))
@@ -247,10 +248,12 @@ fun MetricDisplayItem(title: String, value: String, testTag: String) {
     Text(
         text = title,
         style = AppTypography.smallTitleStyle,
+        color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(bottom = AppDimensions.paddingSmall))
     Text(
         text = value,
         style = AppTypography.smallTitleStyle,
+        color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(bottom = AppDimensions.paddingSmall))
   }
 }


### PR DESCRIPTION
This PR resolves inconsistencies in the dark mode on the feedback screen. The metric text colors were taking the default value, which made them unreadable in dark mode (black text for a black background).
![dark mode feedback](https://github.com/user-attachments/assets/923e8192-5fb1-4c41-aa75-c25e567c983a)
