### PR TITLE
Fix misplaced text elements in the bottom navigation bar

### DIFF
--- a/app/src/main/java/com/github/se/orator/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/orator/ui/navigation/BottomNavigationMenu.kt
@@ -3,9 +3,9 @@ package com.github.se.orator.ui.navigation
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material3.Icon
@@ -27,11 +27,7 @@ fun BottomNavigationMenu(
   val insets = WindowInsets.systemBars.asPaddingValues()
 
   BottomNavigation(
-      modifier =
-          Modifier.fillMaxWidth()
-              .height(AppDimensions.bottomNavigationHeight + insets.calculateBottomPadding())
-              .padding(bottom = insets.calculateBottomPadding())
-              .testTag("bottomNavigationMenu"),
+      modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag("bottomNavigationMenu"),
       backgroundColor = MaterialTheme.colorScheme.surface,
       content = {
         tabList.forEach { tab ->
@@ -54,7 +50,10 @@ fun BottomNavigationMenu(
               label = { Text(tab.textId, color = MaterialTheme.colorScheme.onSurface) },
               selected = tab.route == selectedItem,
               onClick = { onTabSelect(tab) },
-              modifier = Modifier.clip(AppShapes.bottomNavigationItemShape).testTag(tab.textId))
+              modifier =
+                  Modifier.padding(bottom = insets.calculateBottomPadding())
+                      .clip(AppShapes.bottomNavigationItemShape)
+                      .testTag(tab.textId))
         }
       },
   )


### PR DESCRIPTION
The text fields describing each route were not shown entirely on some devices (they were partly too low) in `BottomNavigationMenu.kt`. Now, the padding that was previously preventing the app's bar from going under the android device's bar has been modified : the app's bar is now fully under the android's bar, but the elements (buttons + associated text) composing it are over it (higher than the android bar).


Here is a preview of the new bar : 

<p align="center"><img src="https://github.com/user-attachments/assets/ef2cf433-e480-45d4-98d4-e3f8f7412939" height="600"></p>

Related to issue #334 .