### PR TITLE
Update the allusers list in real time

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepository.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepository.kt
@@ -253,4 +253,19 @@ interface UserProfileRepository {
       onProfileChanged: (UserProfile?) -> Unit,
       onError: (Exception) -> Unit
   )
+
+  /**
+   * Sets up a real-time listener for all user profiles in the data store.
+   *
+   * Listens to changes in the `user_profiles` collection and triggers the [onProfilesChanged]
+   * callback with the updated list whenever a profile is added, modified, or deleted. If an error
+   * occurs, the [onError] callback is invoked.
+   *
+   * @param onProfilesChanged Callback invoked with the updated list of [UserProfile].
+   * @param onError Callback invoked if an error occurs during listening.
+   */
+  fun listenToAllUserProfiles(
+      onProfilesChanged: (List<UserProfile>) -> Unit,
+      onError: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileRepositoryFirestore.kt
@@ -770,4 +770,35 @@ class UserProfileRepositoryFirestore(private val db: FirebaseFirestore) : UserPr
       }
     }
   }
+
+  /**
+   * Sets up a real-time listener for all user profiles in the data store.
+   *
+   * Listens to changes in the `user_profiles` collection and triggers the [onProfilesChanged]
+   * callback with the updated list whenever a profile is added, modified, or deleted. If an error
+   * occurs, the [onError] callback is invoked.
+   *
+   * @param onProfilesChanged Callback invoked with the updated list of [UserProfile].
+   * @param onError Callback invoked if an error occurs during listening.
+   */
+  override fun listenToAllUserProfiles(
+      onProfilesChanged: (List<UserProfile>) -> Unit,
+      onError: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath).addSnapshotListener { querySnapshot, e ->
+      if (e != null) {
+        // Error occurred
+        onError(e)
+        return@addSnapshotListener
+      }
+      if (querySnapshot != null) {
+        // Map documents to UserProfile objects
+        val profiles = querySnapshot.documents.mapNotNull { documentToUserProfile(it) }
+        onProfilesChanged(profiles)
+      } else {
+        // If we get a null snapshot, return an empty list
+        onProfilesChanged(emptyList())
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/profile/UserProfileViewModel.kt
@@ -746,4 +746,14 @@ class UserProfileViewModel(internal val repository: UserProfileRepository) : Vie
         },
         onError = { Log.e("UserProfileViewModel", "Error listening to user profile updates", it) })
   }
+
+  /** Starts a real-time listener on the entire user profiles collection. */
+  fun startListeningToAllProfiles() {
+    repository.listenToAllUserProfiles(
+        onProfilesChanged = { profiles ->
+          // Update the state flow with the new list of all profiles
+          allProfiles_.value = profiles
+        },
+        onError = { Log.e("UserProfileViewModel", "Error listening to all user profiles", it) })
+  }
 }

--- a/app/src/main/java/com/github/se/orator/ui/authentification/SignIn.kt
+++ b/app/src/main/java/com/github/se/orator/ui/authentification/SignIn.kt
@@ -65,6 +65,7 @@ fun SignInScreen(navigationActions: NavigationActions, viewModel: UserProfileVie
             val uid = result.user?.uid
             if (uid != null) {
               viewModel.startListeningToUserProfile(uid)
+              viewModel.startListeningToAllProfiles()
             }
             uid?.let { u ->
               viewModel.getUserProfile(u) // Fetch user profile


### PR DESCRIPTION
### **PR Title:** Add Real-Time Listener for User Profiles to Update All Profiles Dynamically

### **Description:**
This PR introduces a real-time listener for all user profiles, enabling dynamic updates to the list of user profiles in real time. Previously, users who were online could not search for newly created profiles until they refreshed or reloaded the data manually. This issue has been resolved by adding a listener to the `user_profiles` collection, ensuring that any additions, updates, or deletions are reflected immediately for online users.

### **Key Changes:**
1. **Repository:**
   - Introduced a new method `listenToAllUserProfiles` in `UserProfileRepositoryFirestore`.
   - The method listens to changes in the `user_profiles` collection and triggers:
     - **`onProfilesChanged`**: Updates the list of user profiles dynamically.
     - **`onError`**: Handles any errors during the real-time listening process.
   - Handles null snapshots gracefully by providing an empty list to ensure robustness.

2. **ViewModel:**
   - Added a new method `startListeningToAllProfiles` in `UserProfileViewModel`.
   - This method invokes the repository’s `listenToAllUserProfiles` and updates the state flow (`allProfiles_`) with the latest list of user profiles.
   - Proper logging added for error scenarios for easier debugging.

3. **Issue Resolved:**
   - Fixed a bug where users could not search for newly created profiles in real time if they were online. The changes ensure that the profiles list is always up-to-date.

### **Testing:**
- Verified that the real-time listener properly updates the list of user profiles whenever a profile is added, modified, or deleted.
- Tested error handling to confirm graceful fallback and accurate logging.

### **Impact:**
- Improves the user experience by providing real-time updates to the profiles list.
- Resolves the issue reported in [#323](https://github.com/SWENT-TEAM17/OratorAI/issues/323).

### **How to Test:**
1. Run the application.
2. Create a new user profile in the database while keeping an online user session active.
3. Verify that the new profile appears in the user’s profiles list without requiring a manual refresh or reload.
