### PR TITLE
Fix erroneous `Log.e` in `ApiLinkViewModel.kt`

### DIFF
--- a/app/src/main/java/com/github/se/orator/model/apiLink/ApiLinkViewModel.kt
+++ b/app/src/main/java/com/github/se/orator/model/apiLink/ApiLinkViewModel.kt
@@ -43,7 +43,7 @@ class ApiLinkViewModel : ViewModel() {
    */
   fun updatePracticeContext(practiceContext: PracticeContext) {
     _practiceContext.value = practiceContext
-    Log.e("ApiLinkViewModel", "Practice context: $practiceContext")
+    Log.d("ApiLinkViewModel", "Practice context updated: $practiceContext")
   }
 
   /** Sets the analysis data field to null */


### PR DESCRIPTION
`Log.e` was called instead of `Log.d`.